### PR TITLE
fix to ensure slugs are created at a page level

### DIFF
--- a/packages/plugins/src/TableOfContentsPlugin.mjs.ts
+++ b/packages/plugins/src/TableOfContentsPlugin.mjs.ts
@@ -13,8 +13,8 @@ type TOCItem = { level: number; id: string; text: string };
 const TableOfContentsPlugin: PluginType<{}, { minRank: 2; maxRank: 4 }> = {
   async $afterSource(pages: Page[], {}, { minRank, maxRank }) {
     const processor = unified().use(markdown);
-    const slugger = new Slugger();
-    for (const page of pages) {
+    for (const page of pages) {    
+      const slugger = new Slugger();
       const tree = await processor.parse(page.content);
       const items: TOCItem[] = [];
       visit(


### PR DESCRIPTION
one slugger was being used for all pages, leading to links like 'introduction-12'
this change fixes that 