### PR TITLE
create MosaicProvider

### DIFF
--- a/packages/site-components/src/MosaicProvider.tsx
+++ b/packages/site-components/src/MosaicProvider.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Head from 'next/head';
+import { BaseUrlProvider } from './BaseUrlProvider';
+import { Image } from './Image';
+import { Link } from './Link';
+import { Metadata } from './Metadata';
+import { SessionProvider } from './SessionProvider';
+import { SidebarProvider } from './SidebarProvider';
+import { ImageProvider, LinkProvider, ThemeProvider } from '@jpmorganchase/mosaic-components';
+import { useCreateStore, StoreProvider } from '@jpmorganchase/mosaic-store';
+
+export const MosaicProvider = ({ session, storeProps, children }) => {
+  const createStore = useCreateStore(storeProps);
+  return (
+    <SessionProvider session={session}>
+      <StoreProvider value={createStore()}>
+        <Metadata Component={Head} />
+        <ThemeProvider>
+          <BaseUrlProvider>
+            <ImageProvider value={Image}>
+              <LinkProvider value={Link}>
+                <SidebarProvider>{children}</SidebarProvider>
+              </LinkProvider>
+            </ImageProvider>
+          </BaseUrlProvider>
+        </ThemeProvider>
+      </StoreProvider>
+    </SessionProvider>
+  );
+};

--- a/packages/site-components/src/index.tsx
+++ b/packages/site-components/src/index.tsx
@@ -13,6 +13,7 @@ export * from './HTMLView';
 export * from './Link';
 export * from './Image';
 export * from './Metadata';
+export * from './MosaicProvider';
 export * from './SessionProvider';
 export * from './SidebarProvider';
 export * from './TableOfContents';

--- a/packages/standard-generator/src/templates/src/pages/_app.tsx.hbs
+++ b/packages/standard-generator/src/templates/src/pages/_app.tsx.hbs
@@ -1,17 +1,7 @@
 // eslint-disable import/no-duplicates
 import { AppProps } from 'next/app';
-import Head from 'next/head';
-import {
-BaseUrlProvider,
-Image,
-Link,
-Metadata,
-SessionProvider,
-SidebarProvider
-} from '@jpmorganchase/mosaic-site-components';
-import { ImageProvider, LinkProvider, ThemeProvider } from '@jpmorganchase/mosaic-components';
+import { MosaicProvider } from '@jpmorganchase/mosaic-site-components';
 import { LayoutProvider } from '@jpmorganchase/mosaic-layouts';
-import { useCreateStore, StoreProvider } from '@jpmorganchase/mosaic-store';
 {{{ printImports imports }}}
 
 import { MyAppProps } from '../types/mosaic';
@@ -23,25 +13,12 @@ export default function MyApp({ Component, pageProps = {} }: AppProps<MyAppProps
   const { session, sharedConfig, source: { frontmatter = {} } = {} } = pageProps;
 
   const storeProps = { sharedConfig, ...frontmatter };
-  const createStore = useCreateStore(storeProps);
+
   return (
-  <SessionProvider session={session}>
-    <StoreProvider value={createStore()}>
-      <Metadata Component={Head} />
-      <ThemeProvider>
-        <BaseUrlProvider>
-          <ImageProvider value={Image}>
-            <LinkProvider value={Link}>
-              <SidebarProvider>
-                <LayoutProvider layoutComponents={layoutComponents}>
-                  <Component components={components} {...pageProps} />
-                </LayoutProvider>
-              </SidebarProvider>
-            </LinkProvider>
-          </ImageProvider>
-        </BaseUrlProvider>
-      </ThemeProvider>
-    </StoreProvider>
-  </SessionProvider>
+    <MosaicProvider session={session} storeProps={storeProps}>
+      <LayoutProvider layoutComponents={layoutComponents}>
+        <Component components={components} {...pageProps} />
+      </LayoutProvider>
+    </MosaicProvider>
   );
-  }
+}


### PR DESCRIPTION
could combine it like this
so if we make changes to the providers used then consumers update it by updating their mosaic-site-components package, instead of having to edit the _app.tsx file/ use codemods

have also considered making a separate provider package and also incorporating LayoutProvider in this so it would look like
   `<MosaicProvider session={session} storeProps={storeProps} layoutComponents={layoutComponents}>
        <Component components={components} {...pageProps} />
    </MosaicProvider>`

or could we go as far as including Component as well
`<MosaicProvider session={session} storeProps={storeProps} layoutComponents={layoutComponents} component={       <Component components={components} {...pageProps} />}/>`