### PR TITLE
Search results-list truncation

### DIFF
--- a/packages/site-components/src/SearchInput/Results.tsx
+++ b/packages/site-components/src/SearchInput/Results.tsx
@@ -25,6 +25,8 @@ interface ResultListItemProps {
   onSelect: (result) => void;
 }
 
+const MAX_RESULTS = 10;
+
 function ResultListItem({ result, query, onSelect }: ResultListItemProps) {
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
@@ -96,6 +98,9 @@ function ResultListItemEmpty() {
     </article>
   );
 }
+function ResultListItemOverflow({ overflow }: { overflow: number }) {
+  return <P6 className={styles.itemOverflow}>Plus {overflow} more...</P6>;
+}
 
 export function ResultsList({ searchResults, query, handleClear }: SearchResultsListProps) {
   const router = useRouter();
@@ -109,14 +114,19 @@ export function ResultsList({ searchResults, query, handleClear }: SearchResults
     <div className={styles.popper} role="tooltip">
       <div className={styles.resultsList}>
         {searchResults.length > 0 ? (
-          searchResults.map(result => (
-            <ResultListItem
-              key={`result-item-${result.route}`}
-              result={result}
-              query={query}
-              onSelect={handleSelect}
-            />
-          ))
+          <>
+            {searchResults.slice(0, MAX_RESULTS).map(result => (
+              <ResultListItem
+                key={`result-item-${result.route}`}
+                result={result}
+                query={query}
+                onSelect={handleSelect}
+              />
+            ))}
+            {searchResults.length > MAX_RESULTS && (
+              <ResultListItemOverflow overflow={searchResults.length - MAX_RESULTS} />
+            )}
+          </>
         ) : (
           <ResultListItemEmpty />
         )}

--- a/packages/site-components/src/SearchInput/index.tsx
+++ b/packages/site-components/src/SearchInput/index.tsx
@@ -27,8 +27,8 @@ export function SearchInput() {
   useEffect(() => {
     const keys = ['title', 'content'];
     const results = performSearch(searchIndex, searchTerm, keys);
-    setListVisibility(true);
     setSearchResults(results);
+    setListVisibility(true);
   }, [searchTerm]);
 
   const handleInputFocus = () => {

--- a/packages/site-components/src/SearchInput/styles.css.ts
+++ b/packages/site-components/src/SearchInput/styles.css.ts
@@ -35,8 +35,10 @@ export default {
   resultsList: style([style({ width: '500px' })]),
   item: style([
     foregroundColor({ variant: 'mid' }),
+    responsiveSprinkles({
+      padding: ['x2', 'x2', 'x2', 'x2']
+    }),
     style({
-      padding: '9px 8px',
       height: '100%',
       cursor: 'pointer',
       boxSizing: 'border-box',
@@ -60,5 +62,17 @@ export default {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap'
-  })
+  }),
+  itemOverflow: style([
+    responsiveSprinkles({
+      padding: ['x2', 'x2', 'x2', 'x2']
+    }),
+    style({
+      textAlign: 'center',
+      display: 'block',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap'
+    })
+  ])
 };


### PR DESCRIPTION
Searches with lots of results would create a list that overflowed the bottom of the page.
This change forces the results list to only ever show a maximum of 10 results at once.
Adds a "plus {N} more..." message to show how many results a search has found.

For this PR, `MAX_RESULTS` const is hardcoded to be 10, but the plan is to expose this into the options settings for the plugin (coming in a future PR)