### PR TITLE
remove fixed width of sidebar as responsive sizing is managed by theme

### DIFF
--- a/packages/site-components/src/Sidebar/styles.css.ts
+++ b/packages/site-components/src/Sidebar/styles.css.ts
@@ -4,7 +4,6 @@ import { sidebar } from '@jpmorganchase/mosaic-theme';
 export default {
   root: style([
     {
-      width: '400px',
       zIndex: 3
     },
     sidebar.container

--- a/packages/theme/src/sidebar/sidebar.css.ts
+++ b/packages/theme/src/sidebar/sidebar.css.ts
@@ -10,7 +10,7 @@ export const sidebarProperties = defineProperties({
   responsiveArray: ['mobile', 'tablet', 'web', 'desktop'],
   properties: {
     display: ['block', 'none'],
-    width: { none: '0px', wide: '40%', narrow: '23%', drawer: '100vw' }
+    width: { none: '0px', wide: '30%', drawer: '100vw' }
   }
 });
 


### PR DESCRIPTION
Previously when at tablet breakpoint the sidebar was not full width.