### PR TITLE
Sidebar priority2

### DIFF
--- a/.changeset/happy-actors-cover.md
+++ b/.changeset/happy-actors-cover.md
@@ -1,0 +1,31 @@
+---
+'@jpmorganchase/mosaic-plugins': patch
+'@jpmorganchase/mosaic-cli': patch
+'@jpmorganchase/mosaic-components': patch
+'@jpmorganchase/mosaic-labs-components': patch
+'@jpmorganchase/mosaic-content-editor-plugin': patch
+'@jpmorganchase/mosaic-core': patch
+'@jpmorganchase/mosaic-create-site': patch
+'@jpmorganchase/mosaic-from-http-request': patch
+'@jpmorganchase/mosaic-layouts': patch
+'@jpmorganchase/mosaic-open-api-component': patch
+'@jpmorganchase/mosaic-schemas': patch
+'@jpmorganchase/mosaic-serialisers': patch
+'@jpmorganchase/mosaic-site': patch
+'@jpmorganchase/mosaic-site-components': patch
+'@jpmorganchase/mosaic-site-middleware': patch
+'@jpmorganchase/mosaic-site-preset-styles': patch
+'@jpmorganchase/mosaic-source-git-repo': patch
+'@jpmorganchase/mosaic-source-http': patch
+'@jpmorganchase/mosaic-source-local-folder': patch
+'@jpmorganchase/mosaic-standard-generator': patch
+'@jpmorganchase/mosaic-store': patch
+'@jpmorganchase/mosaic-theme': patch
+'@jpmorganchase/mosaic-types': patch
+'@jpmorganchase/mosaic-workflows': patch
+---
+
+1. Pip Salt version
+2. Issues 155, make 500 error more specific
+3. button and sidebar styles
+4. search opt-out

--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -154,7 +154,7 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
 
       //Map into Sidebar Groups and sort children according to priority
       function sortSidebarGroups(sidebarData) {
-        let sortedGroupedPages = sidebarData.map(page => {
+        const sortedGroupedPages = sidebarData.map(page => {
           if (page.childNodes.length > 1) {
             const sortedPages = page.childNodes.sort(
               (pageA, pageB) =>

--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -15,21 +15,6 @@ function createFileGlob(patterns, pageExtensions) {
   return `${patterns}{${pageExtensions.join(',')}}`;
 }
 
-function sortPagesByPriority(pageA, pageB, dirName) {
-  // Always pin /index to the front
-  const route = `${dirName}/index`;
-  if (pageA.route === route) {
-    return -1;
-  }
-  if (pageB.route === route) {
-    return 1;
-  }
-  return (
-    (pageB.sidebar && pageB.sidebar.priority ? pageB.sidebar.priority : -1) -
-    (pageA.sidebar && pageA.sidebar.priority ? pageA.sidebar.priority : -1)
-  );
-}
-
 function getPageLevel(page) {
   return page.route.split('/').length - 2;
 }
@@ -39,8 +24,6 @@ function sortByPathLevel(pathA, pathB) {
   const pathBLevel = pathB.split('/').length;
   return pathBLevel - pathALevel;
 }
-
-const filterPages = page => !(page.sidebar && page.sidebar.exclude);
 
 interface SidebarPluginConfigData {
   dirs: string[];
@@ -87,9 +70,6 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
               )
           )
         );
-        pageList = pageList
-          .filter(page => filterPages(page))
-          .sort((pageA, pageB) => sortPagesByPriority(pageA, pageB, dirName));
         return pageList;
       }
 
@@ -172,14 +152,17 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
         deep: sidebarRootLevel
       });
 
-      //Map into Sidebar Groups and sort children according to priority, priority = 1 has the highest priority
+      //Map into Sidebar Groups and sort children according to priority
       function sortSidebarGroups(sidebarData) {
-        const sortedGroupedPages = sidebarData.map(page => {
-          if (page.childNodes) {
+        let sortedGroupedPages = sidebarData.map(page => {
+          if (page.childNodes.length > 1) {
             const sortedPages = page.childNodes.sort((a, b) => b.priority - a.priority);
+            console.log(page.childNodes);
+            sortSidebarGroups(page.childNodes);
+            console.log({ sortedPages });
             return { ...page, childNodes: sortedPages };
           } else {
-            page;
+            return page;
           }
         });
         return sortedGroupedPages;

--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -156,10 +156,11 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
       function sortSidebarGroups(sidebarData) {
         let sortedGroupedPages = sidebarData.map(page => {
           if (page.childNodes.length > 1) {
-            const sortedPages = page.childNodes.sort((a, b) => b.priority - a.priority);
-            console.log(page.childNodes);
+            const sortedPages = page.childNodes.sort(
+              (pageA, pageB) =>
+                (pageB.priority ? pageB.priority : -1) - (pageA.priority ? pageA.priority : -1)
+            );
             sortSidebarGroups(page.childNodes);
-            console.log({ sortedPages });
             return { ...page, childNodes: sortedPages };
           } else {
             return page;


### PR DESCRIPTION
- Add recursive sort function that orders the pages based on the sidebar priority
- Function moved to after the pages are grouped therefore the ./index page doesn't need to be pinned to the front (this code has been removed). This is because after the createGroupMap function the ./index pages are the parents and pages of the same length and routeDir are contained in the ChildNodes array