### PR TITLE
change `nextImageClassName` type to optional

### DIFF
--- a/packages/site-components/src/Image/index.tsx
+++ b/packages/site-components/src/Image/index.tsx
@@ -13,7 +13,7 @@ export type ImageProps = Omit<NextImageProps, 'src'> & {
   /**
    * class name to apply to the inner Next Image component
    */
-  nextImageClassName: string;
+  nextImageClassName?: string;
 };
 
 export const Image: FC<ImageProps> = forwardRef(


### PR DESCRIPTION
Currently an empty string would need to be passed to satisfy the type, making it optional so it can be used without an added class