### PR TITLE
Locally scoped theme contract

### DIFF
--- a/.changeset/grumpy-knives-nail.md
+++ b/.changeset/grumpy-knives-nail.md
@@ -1,0 +1,28 @@
+---
+'@jpmorganchase/mosaic-components': minor
+'@jpmorganchase/mosaic-site': minor
+'@jpmorganchase/mosaic-standard-generator': minor
+'@jpmorganchase/mosaic-theme': minor
+'@jpmorganchase/mosaic-cli': minor
+'@jpmorganchase/mosaic-labs-components': minor
+'@jpmorganchase/mosaic-content-editor-plugin': minor
+'@jpmorganchase/mosaic-core': minor
+'@jpmorganchase/mosaic-create-site': minor
+'@jpmorganchase/mosaic-from-http-request': minor
+'@jpmorganchase/mosaic-layouts': minor
+'@jpmorganchase/mosaic-open-api-component': minor
+'@jpmorganchase/mosaic-plugins': minor
+'@jpmorganchase/mosaic-schemas': minor
+'@jpmorganchase/mosaic-serialisers': minor
+'@jpmorganchase/mosaic-site-components': minor
+'@jpmorganchase/mosaic-site-middleware': minor
+'@jpmorganchase/mosaic-site-preset-styles': minor
+'@jpmorganchase/mosaic-source-git-repo': minor
+'@jpmorganchase/mosaic-source-http': minor
+'@jpmorganchase/mosaic-source-local-folder': minor
+'@jpmorganchase/mosaic-store': minor
+'@jpmorganchase/mosaic-types': minor
+'@jpmorganchase/mosaic-workflows': minor
+---
+
+The theme contract provided by the `@jpmorganchase/mosaic-theme` package now uses locally scoped variable names via a Vanilla Extract [Theme Contract](https://vanilla-extract.style/documentation/api/create-theme-contract/). Previously the theme variables were globally scoped resulting in conflicts with other design systems.

--- a/packages/components/src/ThemeProvider.tsx
+++ b/packages/components/src/ThemeProvider.tsx
@@ -12,13 +12,18 @@ const useHasHydrated = () => {
   return hasHydrated;
 };
 
-export function ThemeProvider({ children }: { children?: ReactNode }) {
+interface ThemeProviderProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+export function ThemeProvider({ className, children }: ThemeProviderProps) {
   const hasHydrated = useHasHydrated();
   const colorMode = useColorMode();
 
   return (
     <SaltProvider applyClassesTo="child" mode={hasHydrated ? colorMode : 'light'}>
-      <div>
+      <div className={className}>
         {children}
         <div data-mosaic-id="portal-root" />
       </div>

--- a/packages/site/src/pages/_app.tsx
+++ b/packages/site/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { LayoutProvider } from '@jpmorganchase/mosaic-layouts';
 import { useCreateStore, StoreProvider } from '@jpmorganchase/mosaic-store';
 import { components as mosaicComponents } from '@jpmorganchase/mosaic-site-components';
 import { layouts as mosaicLayouts } from '@jpmorganchase/mosaic-layouts';
+import { themeClassName } from '@jpmorganchase/mosaic-theme';
 import '@jpmorganchase/mosaic-site-preset-styles/index.css';
 import { SessionProvider } from 'next-auth/react';
 
@@ -24,7 +25,7 @@ export default function MyApp({ Component, pageProps = {} }: AppProps<MyAppProps
     <SessionProvider>
       <StoreProvider value={createStore()}>
         <Metadata Component={Head} />
-        <ThemeProvider>
+        <ThemeProvider className={themeClassName}>
           <BaseUrlProvider>
             <ImageProvider value={Image}>
               <LinkProvider value={Link}>

--- a/packages/site/tsconfig.json
+++ b/packages/site/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2022",
     "lib": ["es2022", "DOM", "DOM.iterable"],
     "esModuleInterop": true,
-    "moduleResolution": "Node16",
+    "moduleResolution": "Node",
     "isolatedModules": true,
     "sourceMap": true,
     "declaration": true,

--- a/packages/standard-generator/src/templates/src/pages/_app.tsx.hbs
+++ b/packages/standard-generator/src/templates/src/pages/_app.tsx.hbs
@@ -11,6 +11,7 @@ import {
 import { SessionProvider } from 'next-auth/react';
 import { ImageProvider, LinkProvider, ThemeProvider } from '@jpmorganchase/mosaic-components';
 import { LayoutProvider } from '@jpmorganchase/mosaic-layouts';
+import { themeClassName } from '@jpmorganchase/mosaic-theme';
 import { useCreateStore, StoreProvider } from '@jpmorganchase/mosaic-store';
 {{{ printImports imports }}}
 
@@ -28,7 +29,7 @@ export default function MyApp({ Component, pageProps = {} }: AppProps<MyAppProps
     <SessionProvider>
       <StoreProvider value={createStore()}>
         <Metadata Component={Head} />
-        <ThemeProvider>
+        <ThemeProvider className={themeClassName}>
           <BaseUrlProvider>
             <ImageProvider value={Image}>
               <LinkProvider value={Link}>

--- a/packages/standard-generator/src/templates/tsconfig.json
+++ b/packages/standard-generator/src/templates/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2022",
     "lib": ["es2022", "DOM", "DOM.iterable"],
     "esModuleInterop": true,
-    "moduleResolution": "Node16",
+    "moduleResolution": "Node",
     "isolatedModules": true,
     "sourceMap": true,
     "declaration": true,

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -9,13 +9,15 @@
     "url": "git@github.com:jpmorganchase/mosaic.git",
     "directory": "packages/theme"
   },
+  "types": "./dist/index.d.ts",
+  "style": "./dist/index.css",
   "exports": {
     "./index.css": "./dist/index.css",
     "./baseline.css": "./dist/baseline/index.css",
     "./salt.css": "./dist/salt/index.css",
     ".": {
-      "style": "./dist/index.css",
       "types": "./dist/index.d.ts",
+      "style": "./dist/index.css",
       "import": "./dist/index.js",
       "node": "./dist/index.js"
     }

--- a/packages/theme/src/vars.css.ts
+++ b/packages/theme/src/vars.css.ts
@@ -1,6 +1,5 @@
-import { createGlobalTheme, createGlobalThemeContract } from '@vanilla-extract/css';
+import { createTheme, createThemeContract } from '@vanilla-extract/css';
 
-import { lightMode, darkMode } from './color/lightMode';
 import { borderVars } from './border/vars.css';
 import { colorVars } from './color/vars.css';
 import { buttonVars } from './button/vars.css';
@@ -15,28 +14,26 @@ import { shadowVars } from './shadow/vars.css';
 import { spaceVars } from './responsive/vars.css';
 import { tableVars } from './table/vars.css';
 
-const vars = createGlobalThemeContract(
-  {
-    border: borderVars,
-    color: colorVars,
-    component: {
-      button: buttonVars,
-      componentExample: componentExampleVars,
-      grid: gridVars,
-      hero: heroVars,
-      impact: impactVars,
-      list: listVars,
-      table: tableVars
-    },
-    fontSize: fontSizeVars,
-    fontWeight: fontWeightVars,
-    opacity: opacityVars,
-    shadow: shadowVars,
-    space: spaceVars
+const vars = createThemeContract({
+  border: borderVars,
+  color: colorVars,
+  component: {
+    button: buttonVars,
+    componentExample: componentExampleVars,
+    grid: gridVars,
+    hero: heroVars,
+    impact: impactVars,
+    list: listVars,
+    table: tableVars
   },
-  (_, path) => `${path.join('-')}`
-);
-const themeClassName = createGlobalTheme(`${lightMode},${darkMode}`, vars, {
+  fontSize: fontSizeVars,
+  fontWeight: fontWeightVars,
+  opacity: opacityVars,
+  shadow: shadowVars,
+  space: spaceVars
+});
+
+const themeClassName = createTheme(vars, {
   border: borderVars,
   color: colorVars,
   component: {

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -1,26 +1,3 @@
-/**
-{
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "target": "es2015",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "isolatedModules": true,
-    "rootDir": "src",
-    "outDir": "dist/types",
-    "jsx": "react",
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "noEmit": false
-  },
-  "include": ["src"]
-}
-*/
 {
   "extends": "../../tsconfig.bundle.json",
   "compilerOptions": {


### PR DESCRIPTION
Replaces the use of [Global Theme Contract](https://vanilla-extract.style/documentation/global-api/create-global-theme-contract/) with a scoped [Theme Contract](https://vanilla-extract.style/documentation/api/create-theme-contract/)

This should make it easier to build and use themes.