### PR TITLE
enable sidebar root(s) to be configured

### DIFF
--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -40,8 +40,8 @@ interface SidebarPluginOptions {
   filename: string;
   /**
    * Glob pattern for matching directories which should be the root of the sidebar
-   * ** creates a root level sidebar containing all pages
-   * *\/* creates a sidebar under each of the root directories
+   * * creates a root level sidebar containing all pages underneath root
+   * *\/* creates a separate sidebar under each of the root directories
    */
   rootDirGlob: string;
 }
@@ -60,7 +60,7 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
     async $beforeSend(
       mutableFilesystem,
       { config, serialiser, ignorePages, pageExtensions },
-      { filename = 'sidebar.json', rootDirGlob = '**' }
+      { filename = 'sidebar.json', rootDirGlob = '*' }
     ) {
       /**
        * Create a list of pages that should be used to build a sidebar.json
@@ -214,6 +214,7 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
         extglob: true,
         cwd: '/'
       });
+      console.log('rootUserJourneys', rootUserJourneys);
 
       const removeExcludedPages = page => !(page.sidebar && page.sidebar.exclude);
 

--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -2,9 +2,6 @@ import path from 'path';
 import type { Plugin as PluginType, Page } from '@jpmorganchase/mosaic-types';
 import { cloneDeep } from 'lodash-es';
 
-// Which level does sidebar creation start
-const sidebarRootLevel = 1;
-
 function createFileGlob(patterns, pageExtensions) {
   if (Array.isArray(patterns)) {
     return patterns.map(pattern => createFileGlob(pattern, pageExtensions));
@@ -37,11 +34,20 @@ interface SidebarPluginPage extends Page {
 }
 
 interface SidebarPluginOptions {
+  /**
+   * filename of the sidebar json, linked to each related page via ref
+   */
   filename: string;
+  /**
+   * Glob pattern for matching directories which should be the root of the sidebar
+   * ** creates a root level sidebar containing all pages
+   * *\/* creates a sidebar under each of the root directories
+   */
+  rootDirGlob: string;
 }
 
 /**
- * Sorts the pages in a folder by priority and then exports a JSON file (name: `options.filename`) with the
+ * Sorts the pages in a folder by priority and then exports a JSON file with the
  * sidebar tree from that directory downwards and adds sidebar data into frontmatter for each page.
  *
  * Additionally, add to frontmatter
@@ -54,26 +60,31 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
     async $beforeSend(
       mutableFilesystem,
       { config, serialiser, ignorePages, pageExtensions },
-      options
+      { filename = 'sidebar.json', rootDirGlob = '**' }
     ) {
       /**
        * Create a list of pages that should be used to build a sidebar.json
        * @param dirName - root path of sidebar
        */
-      async function createPageList(dirName) {
-        let pageList = await Promise.all(
-          (
-            (await mutableFilesystem.promises.glob(createFileGlob(['**'], pageExtensions), {
-              cwd: String(dirName),
-              ignore: ignorePages.map(ignore => `**/${ignore}`)
-            })) as string[]
-          ).map(
-            async pagePath =>
-              await serialiser.deserialise(
-                pagePath,
-                await mutableFilesystem.promises.readFile(pagePath)
-              )
-          )
+      async function createPageList(rootDir) {
+        const isChildOfRootDir = pagePath => {
+          const pageDir = path.dirname(pagePath);
+          return pageDir.indexOf(rootDir) === 0;
+        };
+        const pagePaths = (await mutableFilesystem.promises.glob(
+          createFileGlob(['**'], pageExtensions),
+          {
+            cwd: String(rootDir),
+            ignore: ignorePages.map(ignore => `**/${ignore}`)
+          }
+        )) as string[];
+        const filteredPagePaths = pagePaths.filter(isChildOfRootDir);
+        const pageList = await Promise.all(
+          filteredPagePaths.map(async pagePath => {
+            return mutableFilesystem.promises.readFile(pagePath).then(serializedContent => {
+              return serialiser.deserialise(pagePath, serializedContent);
+            });
+          })
         );
         return pageList;
       }
@@ -147,7 +158,7 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
           config.setRef(
             String(page.fullPath),
             ['sidebarData', '$ref'],
-            path.posix.join(dirName, options.filename, '#', 'pages')
+            path.posix.join(dirName, filename, '#', 'pages')
           );
         });
       }
@@ -198,10 +209,10 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
         recursiveAddNavigation(pages);
       }
 
-      const rootUserJourneys = await mutableFilesystem.promises.glob('**', {
+      const rootUserJourneys = await mutableFilesystem.promises.glob(rootDirGlob, {
         onlyDirectories: true,
-        cwd: '/',
-        deep: sidebarRootLevel
+        extglob: true,
+        cwd: '/'
       });
 
       const removeExcludedPages = page => !(page.sidebar && page.sidebar.exclude);
@@ -223,19 +234,19 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
       }
 
       await Promise.all(
-        rootUserJourneys.map(async dirName => {
-          const sidebarFilePath = path.posix.join(String(dirName), options.filename);
-          let pages = await createPageList(dirName);
+        rootUserJourneys.map(async rootDir => {
+          const sidebarFilePath = path.posix.join(String(rootDir), filename);
+          let pages = await createPageList(rootDir);
           pages = pages.filter(page => removeExcludedPages(page));
           const groupMap = createGroupMap(pages);
-          const sidebarData = linkGroupMap(groupMap, dirName);
+          const sidebarData = linkGroupMap(groupMap, rootDir);
           const pagesByPriority = sortPagesByPriority(sidebarData);
           addNavigationToFrontmatter(pagesByPriority);
           await mutableFilesystem.promises.writeFile(
             sidebarFilePath,
             JSON.stringify({ pages: pagesByPriority })
           );
-          addSidebarDataToFrontmatter(pages, dirName);
+          addSidebarDataToFrontmatter(pages, rootDir);
         })
       );
     }

--- a/packages/plugins/src/__tests__/SidebarPlugin.test.ts
+++ b/packages/plugins/src/__tests__/SidebarPlugin.test.ts
@@ -1,98 +1,57 @@
+import path from 'path';
 import SidebarPlugin, { SidebarPluginPage } from '../SidebarPlugin';
 
-const folderAPages: SidebarPluginPage[] = [
-  {
-    fullPath: '/folderA/index.mdx',
-    route: 'route/folderA/index',
-    title: 'Folder A Index',
-    layout: 'DetailOverview'
-  },
-  {
-    fullPath: '/folderA/pageA.mdx',
-    route: 'route/folderA/pageA',
-    title: 'Folder A Page A',
-    layout: 'DetailOverview'
-  },
-  {
-    fullPath: '/folderA/pageB.mdx',
-    route: 'route/folderA/pageB',
-    title: 'Folder A Page B',
-    layout: 'DetailOverview'
-  },
-  {
-    fullPath: '/folderA/SubfolderA/index.mdx',
-    route: 'route/folderA/subfolderA/index',
-    title: 'Subfolder A Index',
-    layout: 'DetailOverview'
-  },
-  {
-    fullPath: '/folderA/SubfolderA/PageA.mdx',
-    route: 'route/folderA/subfolderA/pageA',
-    title: 'Subfolder A Page A',
-    layout: 'DetailOverview'
-  },
-  {
-    fullPath: '/folderA/SubfolderA/PageB.mdx',
-    route: 'route/folderA/subfolderA/pageB',
-    title: 'Subfolder A Page B',
-    layout: 'DetailOverview'
-  }
+const folderAPages: string[] = [
+  '/folderA/index.mdx',
+  '/folderA/pageA.mdx',
+  '/folderA/pageB.mdx',
+  '/folderA/SubfolderA/index.mdx',
+  '/folderA/SubfolderA/PageA.mdx',
+  '/folderA/SubfolderA/PageB.mdx'
 ];
-const folderBPages: SidebarPluginPage[] = [
-  {
-    fullPath: '/folderB/index.mdx',
-    route: 'route/folderB/index',
-    title: 'Folder B Index',
-    layout: 'DetailOverview'
-  },
-  {
-    fullPath: '/folderB/pageA.mdx',
-    route: 'route/folderA/pageA',
-    title: 'Folder B Page A',
-    layout: 'DetailOverview'
-  }
-];
+
+const folderBPages: string[] = ['/folderB/index.mdx', '/folderB/pageA.mdx'];
 
 const folderASidebarContents = {
   pages: [
     {
       id: 'route/folderA/index',
       fullPath: '/folderA/index.mdx',
-      name: 'Folder A Index',
+      name: ' folderA index',
       data: { level: 1, link: 'route/folderA/index' },
       childNodes: [
         {
           id: 'route/folderA/pageA',
           fullPath: '/folderA/pageA.mdx',
-          name: 'Folder A Page A',
+          name: ' folderA pageA',
           data: { level: 1, link: 'route/folderA/pageA' },
           childNodes: []
         },
         {
           id: 'route/folderA/pageB',
           fullPath: '/folderA/pageB.mdx',
-          name: 'Folder A Page B',
+          name: ' folderA pageB',
           data: { level: 1, link: 'route/folderA/pageB' },
           childNodes: []
         },
         {
-          id: 'route/folderA/subfolderA/index',
+          id: 'route/folderA/SubfolderA/index',
           fullPath: '/folderA/SubfolderA/index.mdx',
-          name: 'Subfolder A Index',
-          data: { level: 2, link: 'route/folderA/subfolderA/index' },
+          name: ' folderA SubfolderA index',
+          data: { level: 2, link: 'route/folderA/SubfolderA/index' },
           childNodes: [
             {
-              id: 'route/folderA/subfolderA/pageA',
+              id: 'route/folderA/SubfolderA/PageA',
               fullPath: '/folderA/SubfolderA/PageA.mdx',
-              name: 'Subfolder A Page A',
-              data: { level: 2, link: 'route/folderA/subfolderA/pageA' },
+              name: ' folderA SubfolderA PageA',
+              data: { level: 2, link: 'route/folderA/SubfolderA/PageA' },
               childNodes: []
             },
             {
-              id: 'route/folderA/subfolderA/pageB',
+              id: 'route/folderA/SubfolderA/PageB',
               fullPath: '/folderA/SubfolderA/PageB.mdx',
-              name: 'Subfolder A Page B',
-              data: { level: 2, link: 'route/folderA/subfolderA/pageB' },
+              name: ' folderA SubfolderA PageB',
+              data: { level: 2, link: 'route/folderA/SubfolderA/PageB' },
               childNodes: []
             }
           ]
@@ -107,14 +66,14 @@ const folderBSidebarContents = {
     {
       id: 'route/folderB/index',
       fullPath: '/folderB/index.mdx',
-      name: 'Folder B Index',
+      name: ' folderB index',
       data: { level: 1, link: 'route/folderB/index' },
       childNodes: [
         {
-          id: 'route/folderA/pageA',
+          id: 'route/folderB/pageA',
           fullPath: '/folderB/pageA.mdx',
-          name: 'Folder B Page A',
-          data: { level: 1, link: 'route/folderA/pageA' },
+          name: ' folderB pageA',
+          data: { level: 1, link: 'route/folderB/pageA' },
           childNodes: []
         }
       ]
@@ -137,7 +96,17 @@ describe('GIVEN the SidebarPlugin', () => {
           .mockResolvedValueOnce(folderBPages),
         mkdir: jest.fn(),
         readdir: jest.fn(),
-        readFile: jest.fn(),
+        readFile: jest.fn(value =>
+          Promise.resolve({
+            fullPath: value,
+            route: `route${value.replace(/\..*$/, '')}`,
+            title: value
+              .split('/')
+              .map(pathname => path.basename(pathname, '.mdx'))
+              .join(' '),
+            layout: 'some layout'
+          })
+        ),
         realpath: jest.fn(),
         stat: jest.fn(),
         symlink: jest.fn(),
@@ -155,7 +124,7 @@ describe('GIVEN the SidebarPlugin', () => {
           setRef: setRefMock
         },
         serialiser: {
-          deserialise: jest.fn().mockImplementation(value => Promise.resolve(value))
+          deserialise: jest.fn().mockImplementation((_path, value) => Promise.resolve(value))
         },
         ignorePages: [],
         pageExtensions: []

--- a/packages/standard-generator/src/fs.config.js
+++ b/packages/standard-generator/src/fs.config.js
@@ -62,9 +62,7 @@ module.exports = {
     },
     {
       modulePath: '@jpmorganchase/mosaic-plugins/SidebarPlugin',
-      options: {
-        filename: 'sidebar.json'
-      }
+      options: {}
     },
     {
       modulePath: '@jpmorganchase/mosaic-plugins/ReadingTimePlugin',


### PR DESCRIPTION
using `SidebarPlugin` options, add `rootDirGlob`

`rootDirGlob` is a glob pattern for matching directories which should be the root of the sidebar

'**' creates a root level sidebar containing all pages '*/*' creates a sidebar under each of the root directories