### PR TITLE
Lang attribute

### DIFF
--- a/packages/site-components/src/Document.tsx
+++ b/packages/site-components/src/Document.tsx
@@ -8,7 +8,7 @@ export type { DocumentProps } from 'next/document';
 export class Document extends NextDocument {
   render() {
     return (
-      <Html>
+      <Html lang="en">
         <Head>
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />

--- a/packages/site/next.config.js
+++ b/packages/site/next.config.js
@@ -64,9 +64,5 @@ module.exports = {
         permanent: true
       }
     ];
-  },
-  i18n: {
-    locales: ['en'],
-    defaultLocale: 'en'
   }
 };

--- a/packages/standard-generator/src/templates/next.config.js.hbs
+++ b/packages/standard-generator/src/templates/next.config.js.hbs
@@ -52,9 +52,5 @@ module.exports = {
 {{^}}
     return {{{ printNamespaceRedirects sources }}};
 {{/if}}
-  },
-  i18n: {
-    locales: ["en"],
-    defaultLocale: "en",
   }
 };


### PR DESCRIPTION
Using local in next config adds the local into the URL.  We don't need/want that at the moment so the commit that did that has been reverted.

A new commit to manually set the local has been added.