### PR TITLE
disabled sources are filtered from core service

### DIFF
--- a/packages/core/src/PullDocs.ts
+++ b/packages/core/src/PullDocs.ts
@@ -47,7 +47,7 @@ export default class PullDocs {
       serialisers = [],
       pageExtensions = ['.mdx']
     } = config;
-    this.#sourceDefinitions = sources;
+    this.#sourceDefinitions = sources.filter((source: SourceModuleDefinition) => !source.disabled);
     this.#vfs = new UnionVolume(new UnionFileAccess(this.#ufs), '*');
     this.#sourceManager = new SourceManager(
       this.#vfs,

--- a/packages/site/mosaic.config.js
+++ b/packages/site/mosaic.config.js
@@ -27,6 +27,7 @@ module.exports = deepmerge(mosaicConfig, {
      * Access from your browser as http://localhost:3000/local
      */
     {
+      disabled: process.env.NODE_ENV !== 'development',
       modulePath: '@jpmorganchase/mosaic-source-local-folder',
       namespace: 'local', // each site has it's own namespace, think of this as your content's uid
       options: {


### PR DESCRIPTION
This enables us to disable plugins without removing them from the config. A typical use-case is where your config contains both local and remote sources which share the same namespace. With  the `disabled` source option you can enable/disable sources based on environment.

```
  sources: [
    {
      disabled: process.env.NODE_ENV !== 'development',
      modulePath: '@jpmorganchase/mosaic-source-local-folder',
      namespace: 'mynamespace',
      options: {
        rootDir: '../../docs', // relative path to content
        prefixDir: 'mynamespace', // root path used for namespace
        extensions: ['.mdx'] // extensions of content which should be pulled
      }
    }
  ]
```