### PR TITLE
Pin @salt-ds/lab to 1.0.0-alpha.1

### DIFF
--- a/.changeset/ninety-teachers-lick.md
+++ b/.changeset/ninety-teachers-lick.md
@@ -1,0 +1,9 @@
+---
+'@jpmorganchase/mosaic-components': patch
+'@jpmorganchase/mosaic-labs-components': patch
+'@jpmorganchase/mosaic-content-editor-plugin': patch
+'@jpmorganchase/mosaic-layouts': patch
+'@jpmorganchase/mosaic-site-components': patch
+---
+
+Pin @salt-ds/lab to 1.0.0-alpha.1

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mosaic": "node ./packages/cli/dist/index.js",
     "dev": "turbo run dev",
     "e2e": "turbo run e2e --filter=@jpmorganchase/mosaic-site",
-    "e2e:codegen": "turbo run e2e:codegen --filter=@jpmorganchase/mosaic-site",  
+    "e2e:codegen": "turbo run e2e:codegen --filter=@jpmorganchase/mosaic-site",
     "e2e:setup": "npx playwright install",
     "test": "npm-run-all --parallel test:*",
     "test:client": "jest --config ./jest.config.client.js --coverage",
@@ -100,7 +100,6 @@
     "turbo": "latest"
   },
   "resolutions": {
-    "@salt-ds/lab": "1.0.0-alpha.1",
     "@braintree/sanitize-url": "^6.0.0",
     "@types/react": "^18.0.26",
     "commander": "^9.4.0",

--- a/packages/components-labs/package.json
+++ b/packages/components-labs/package.json
@@ -43,7 +43,7 @@
     "@jpmorganchase/mosaic-components": "^0.1.0-beta.26",
     "@jpmorganchase/mosaic-theme": "^0.1.0-beta.26",
     "@salt-ds/core": "^1.0.0",
-    "@salt-ds/lab": "^1.0.0-alpha.0",
+    "@salt-ds/lab": "1.0.0-alpha.1",
     "@vanilla-extract/css": "^1.6.0",
     "@vanilla-extract/recipes": "^0.2.1",
     "@vanilla-extract/sprinkles": "^1.3.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,7 @@
     "@jpmorganchase/mosaic-store": "^0.1.0-beta.26",
     "@jpmorganchase/mosaic-theme": "^0.1.0-beta.26",
     "@salt-ds/core": "^1.0.0",
-    "@salt-ds/lab": "^1.0.0-alpha.0",
+    "@salt-ds/lab": "1.0.0-alpha.1",
     "@vanilla-extract/css": "^1.6.0",
     "@vanilla-extract/sprinkles": "^1.3.0",
     "@vanilla-extract/recipes": "^0.2.1",

--- a/packages/content-editor-plugin/package.json
+++ b/packages/content-editor-plugin/package.json
@@ -42,7 +42,7 @@
     "@jpmorganchase/mosaic-theme": "^0.1.0-beta.26",
     "@salt-ds/core": "^1.0.0",
     "@salt-ds/icons": "^1.0.0",
-    "@salt-ds/lab": "^1.0.0-alpha.0",
+    "@salt-ds/lab": "1.0.0-alpha.1",
     "@salt-ds/theme": "^1.0.0",
     "@lexical/code": "0.5.0",
     "@lexical/link": "0.5.0",

--- a/packages/layouts/package.json
+++ b/packages/layouts/package.json
@@ -42,7 +42,7 @@
     "@jpmorganchase/mosaic-site-components": "^0.1.0-beta.26",
     "@jpmorganchase/mosaic-store": "^0.1.0-beta.26",
     "@jpmorganchase/mosaic-theme": "^0.1.0-beta.26",
-    "@salt-ds/lab": "^1.0.0-alpha.0",
+    "@salt-ds/lab": "1.0.0-alpha.1",
     "@vanilla-extract/css": "^1.6.0",
     "clsx": "^1.2.1",
     "lodash": "^4.17.21",

--- a/packages/site-components/package.json
+++ b/packages/site-components/package.json
@@ -47,7 +47,7 @@
     "@jpmorganchase/mosaic-site-middleware": "^0.1.0-beta.26",
     "@jpmorganchase/mosaic-store": "^0.1.0-beta.26",
     "@jpmorganchase/mosaic-theme": "^0.1.0-beta.26",
-    "@salt-ds/lab": "^1.0.0-alpha.0",
+    "@salt-ds/lab": "1.0.0-alpha.1",
     "@types/mdast": "^3.0.0",
     "@vanilla-extract/css": "^1.6.0",
     "@vanilla-extract/recipes": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3491,7 +3491,7 @@
   dependencies:
     clsx "^1.2.1"
 
-"@salt-ds/lab@1.0.0-alpha.1", "@salt-ds/lab@^1.0.0-alpha.0":
+"@salt-ds/lab@1.0.0-alpha.1":
   version "1.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/@salt-ds/lab/-/lab-1.0.0-alpha.1.tgz#97a4c52deeca1922e8bd4cdb83b6276da9bd88c8"
   integrity sha512-yucQa1+tNSPUw/0rnq/LVoKSUepMCmCRWW7FHnwX0lcPvfJDg4YOZp5ssQlUDzPG3UPT8LQs9JXbmjotb4nkcw==


### PR DESCRIPTION
#237 aimed to fix this but only affects this repo. Consumers will still be upgraded to a version of labs that mosaic doesn't support.