### PR TITLE
fix sidebar styling 

### DIFF
--- a/packages/site-components/src/VerticalNavigation.tsx
+++ b/packages/site-components/src/VerticalNavigation.tsx
@@ -19,47 +19,44 @@ const MenuIcon = ({ open }) => <Icon name={open ? 'chevronDown' : 'chevronRight'
 
 const createMenuItemStyles = colorMode => ({
   subMenuContent: {
-    backgroundColor: 'inherit',
-    color: 'inherit'
+    backgroundColor: 'inherit'
   },
-  button: ({ active, level }) => {
+  button: ({ active }) => {
     let buttonStyle: ElementStyles = {
-      paddingRight: 'var(--space-horizontal-x4)'
+      paddingRight: 'var(--mosaic-space-horizontal-x4)'
     };
-    if (level === 0) {
-      buttonStyle = {
-        ...buttonStyle,
-        paddingLeft: 'var(--space-horizontal-x4)'
-      };
-    }
     return {
       ...buttonStyle,
-      ':active': {
-        backgroundColor: 'unset',
-        color:
-          colorMode === 'light'
-            ? 'var(--color-light-navigable-selectableLink-selectedLabel)'
-            : 'var(--color-dark-navigable-selectableLink-selectedLabel)'
-      },
       ':disabled': {
         backgroundColor: 'unset',
         color:
           colorMode === 'light'
-            ? 'var(--color-light-navigable-selectableLink-unselectedLabel)'
-            : 'var(--color-dark-navigable-selectableLink-unselectedLabel)'
+            ? 'var(--mosaic-color-light-navigable-selectableLink-unselectedLabel)'
+            : 'var(--mosaic-color-dark-navigable-selectableLink-unselectedLabel)'
       },
       ':hover': {
         backgroundColor:
           colorMode === 'light'
-            ? 'var(--color-light-neutral-background-emphasis)'
-            : 'var(--color-dark-neutral-background-emphasis)',
-        color:
-          colorMode === 'light'
-            ? 'var(--color-light-navigable-selectableLink-unselectedLabel)'
-            : 'var(--color-dark-navigable-selectableLink-unselectedLabel)'
+            ? 'var(--mosaic-color-light-neutral-background-emphasis)'
+            : 'var(--mosaic-color-dark-neutral-background-emphasis)'
       },
-      fontWeight: active ? 'var(--fontWeight-bold)' : 'var(--fontWeight-regular)'
+      fontWeight: active ? 'var(--mosaic-fontWeight-semibold)' : 'var(--mosaic-fontWeight-regular)',
+      borderLeft: active
+        ? colorMode === 'light'
+          ? '4px solid var(--mosaic-color-light-navigable-selectableLink-selected)'
+          : '4px solid var(--mosaic-color-dark-navigable-selectableLink-selected)'
+        : '4px solid transparent',
+      color: active
+        ? colorMode === 'light'
+          ? 'var(--mosaic-color-light-navigable-selectableLink-selectedLabel)'
+          : 'var(--mosaic-color-light-navigable-selectableLink-selectedLabel)'
+        : colorMode === 'light'
+        ? 'var(--mosaic-color-light-navigable-selectableLink-unselectedLabel)'
+        : 'var(--mosaic-color-dark-navigable-selectableLink-unselectedLabel)'
     };
+  },
+  label: {
+    marginRight: 'var(--mosaic-space-horizontal-x4)'
   }
 });
 


### PR DESCRIPTION
small changes to sidebar styling to fix some styles that appear broken
problems fixed
- not all buttons change styles on hover
- labels with children have different font colour than labels without children (should all be the same)
- active page is not highlighted in sidebar
- top level of sidebar has 0 left padding

I'm aware that sidebar is being redesigned, but currently I feel the Mosaic site looks unpolished and these changes can temporarily improve that.

Comparison with getting started being hovered, and on page 'Active Mode'
|Before|After|
|-----|-----|
|<img width="443" alt="Screenshot 2023-03-22 at 16 49 03" src="https://user-images.githubusercontent.com/45168453/226978396-d18eff84-c62b-43b6-a94b-70f67739821e.png">|<img width="475" alt="Screenshot 2023-03-22 at 16 38 38" src="https://user-images.githubusercontent.com/45168453/226977178-2fc1b66e-0a5c-49b1-bd17-6ecf3474aca4.png">|
