### PR TITLE
chore: remove mosaic script from standard generator template

### DIFF
--- a/packages/standard-generator/src/templates/package.json.hbs
+++ b/packages/standard-generator/src/templates/package.json.hbs
@@ -8,7 +8,6 @@
   "types": "dist/index.d.ts",
   "style": "dist/index.css",
   "scripts": {
-    "mosaic": "node ../cli/dist/index.js",
     "clean": "rm -fr public/.tmp .next",
     "build": "next build",
     "dev":"next dev",


### PR DESCRIPTION
The "mosaic" command is only needed in our monorepo...people using the template don't need it.