### PR TITLE
fix: load index file if directory requested

### DIFF
--- a/packages/site-middleware/src/loaders/loadLocalFile.ts
+++ b/packages/site-middleware/src/loaders/loadLocalFile.ts
@@ -1,7 +1,12 @@
 import fs from 'fs';
+import path from 'path';
 
 export const loadLocalFile = async (filePath: string): Promise<string> => {
-  const realPath = await fs.promises.realpath(filePath);
+  let localPath = filePath;
+  if ((await fs.promises.stat(filePath)).isDirectory()) {
+    localPath = path.posix.join(localPath, 'index');
+  }
+  const realPath = await fs.promises.realpath(localPath);
   const data = await fs.promises.readFile(realPath, 'utf-8');
   return data.toString();
 };


### PR DESCRIPTION
If a user hits a url that lands on a directory, the index file within that directory is resolved.