### PR TITLE
highlight correct items in toc

### DIFF
--- a/packages/site-components/src/TableOfContents/TableOfContents.tsx
+++ b/packages/site-components/src/TableOfContents/TableOfContents.tsx
@@ -52,7 +52,9 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({ items }) => {
     ) {
       matchHeadingsToDOM();
     } else {
-      const scrollPosition = window.scrollY;
+      const headerElement = document.querySelector('header');
+      const headerHeight = headerElement ? headerElement.getBoundingClientRect().height : 0;
+      const scrollPosition = window.scrollY + headerHeight;
       const newCurrent = mostRecentScrollPoint(scrollPosition, headingPositions.current);
 
       // Only update the current item if we have a valid item (the

--- a/packages/site-components/src/TableOfContents/__tests__/utils.test.tsx
+++ b/packages/site-components/src/TableOfContents/__tests__/utils.test.tsx
@@ -36,15 +36,15 @@ describe('GIVEN a Table Of Contents (TOC)', () => {
   });
 
   describe('WHEN checking scroll position', () => {
-    test('THEN the closest anchor index is returned', () => {
+    test('THEN the next (or last) anchor index is returned', () => {
       const positions = [10, 12, 20, 40, 60, 90];
       const zeroth = mostRecentScrollPoint(5, positions);
       const first = mostRecentScrollPoint(19, positions);
       const second = mostRecentScrollPoint(23, positions);
       const last = mostRecentScrollPoint(9999, positions);
       expect(zeroth).toBe(0);
-      expect(first).toBe(1);
-      expect(second).toBe(2);
+      expect(first).toBe(2);
+      expect(second).toBe(3);
       expect(last).toBe(5);
     });
     test('THEN null is returned if there are no valid points', () => {

--- a/packages/site-components/src/TableOfContents/utils.tsx
+++ b/packages/site-components/src/TableOfContents/utils.tsx
@@ -6,14 +6,14 @@ export const mostRecentScrollPoint = (scrollPosition, allPositions) => {
   // If there are no valid target positions, don't return a target.
   if (validPositions.length <= 0) return null;
 
-  // Nearest will always be the *highest* postion that has been scrolled past.
-  const nearest = validPositions.reduce((acc, position, i) => {
+  // Nearest will be the *highest* position that has not been scrolled past.
+  const nearest = validPositions.reduceRight((acc, position, i) => {
     if (typeof position !== 'number') {
       return acc;
     }
     const scrolledPast = scrollPosition >= position;
-    return scrolledPast ? i : acc;
-  }, 0);
+    return scrolledPast ? acc : i;
+  }, validPositions.length - 1);
   return nearest;
 };
 


### PR DESCRIPTION
The toc was highlighting the last item that had been scrolled past. This pr updates the logic so that it highlights the next item that has not been scrolled past.

This does mean that if there is a short section at the bottom of the page then it will not be highlighted when clicked. This seems to be a general issue in tocs, and I don't think it can be made perfectly to have scrolling and clicking in sync with these small section at the bottom edge cases.

Docusuarus have the same logic, if you click on structured content it will not be highlighted:
https://docusaurus.io/docs/seo

Stripe highlights the last item if clicked, however if you click the penultimate item it will not be highlighted:
https://stripe.com/docs/payments/checkout/how-checkout-works