### PR TITLE
Missing index page warning

### DIFF
--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -204,6 +204,11 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
             }
             if (currPage !== undefined) {
               createNavigationRefs(currPage, prevPage, nextPage);
+            } else if (currPage === undefined) {
+              console.warn(
+                '\x1b[31m',
+                `*** PAGE RETURNING UNDEFINED -  PLEASE CHECK ALL YOUR DIR'S CONTAIN INDEX PAGES. THIS MAY CAUSE ISSUES WITH SIDEBAR AND NAVIGATION ***`
+              );
             }
             recursiveAddNavigation(page.childNodes);
           });
@@ -218,6 +223,12 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
       });
 
       const removeExcludedPages = page => !(page.sidebar && page.sidebar.exclude);
+
+      console.warn(
+        'white',
+        `*****************   THIS PAGE DIR DOES NOT CONTAIN AN INDEX PAGE ************************`,
+        '\x1b[31m'
+      );
 
       function sortPagesByPriority(sidebarData) {
         const pagesByPriority = sidebarData.map(page => {

--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -207,7 +207,7 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
             } else if (currPage === undefined) {
               console.warn(
                 '\x1b[31m',
-                `*** PAGE RETURNING UNDEFINED -  PLEASE CHECK ALL YOUR DIR'S CONTAIN INDEX PAGES. THIS MAY CAUSE ISSUES WITH SIDEBAR AND NAVIGATION ***`
+                `** PAGE RETURNING UNDEFINED -  PLEASE CHECK THAT ALL YOUR DIR'S CONTAIN INDEX PAGES. THIS CAUSES ISSUES WITH SIDEBAR AND NAVIGATION **`
               );
             }
             recursiveAddNavigation(page.childNodes);

--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -224,12 +224,6 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
 
       const removeExcludedPages = page => !(page.sidebar && page.sidebar.exclude);
 
-      console.warn(
-        'white',
-        `*****************   THIS PAGE DIR DOES NOT CONTAIN AN INDEX PAGE ************************`,
-        '\x1b[31m'
-      );
-
       function sortPagesByPriority(sidebarData) {
         const pagesByPriority = sidebarData.map(page => {
           if (page.childNodes.length > 1) {


### PR DESCRIPTION
Problem Statement:
- When a user doesn't include an index page in a DIR the page is returning undefined
- This causes issues with the sidebar and next / prev components

Solution 1: (As seen below)
- We notify users that there are index pages missing in some DIRs
- We still let the site to build but users will see issue when they navigate to a page with a sidebar (We could throw and error and prevent the site from building)

Solution 2:
- Insert code to assign a one of the pages as an Index page
- This changes the 'full path' of the page and could therefore cause issues if that page is linked to in other pages

Solution 3:
- We enable users to have any page names they want 
- This will require the group map in sidebarPlugin and potentially other code changes where index page is used e.g default routing to add /index when the route page dir is hit