### PR TITLE
warning for dir with missing index pages

### DIFF
--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -205,6 +205,12 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
             if (currPage !== undefined) {
               createNavigationRefs(currPage, prevPage, nextPage);
             }
+            if (currPage === undefined) {
+              console.warn(
+                '\x1b[31m',
+                `*** PAGE RETURNING UNDEFINED -  PLEASE CHECK ALL YOUR DIR'S CONTAIN INDEX PAGES. THIS MAY CAUSE ISSUES WITH SIDEBAR AND NAVIGATION ***`
+              );
+            }
             recursiveAddNavigation(page.childNodes);
           });
         }


### PR DESCRIPTION
Problem Statement:

When a user doesn't include an index page in a DIR the page is returning undefined
This causes issues with the sidebar and next / prev components
Solution 1: (As seen below)

We notify users that there are index pages missing in some DIRs
We still let the site to build but users will see issue when they navigate to a page with a sidebar (We could throw and error and prevent the site from building)
Solution 2:

Insert code to assign a one of the pages as an Index page
This changes the 'full path' of the page and could therefore cause issues if that page is linked to in other pages
Solution 3:

We enable users to have any page names they want
This will require the group map in sidebarPlugin and potentially other code changes where index page is used e.g default routing to add /index when the route page dir is hit