### PR TITLE
Pass alt to Image if fill or width and height are not defined

### DIFF
--- a/.changeset/angry-mails-ring.md
+++ b/.changeset/angry-mails-ring.md
@@ -1,0 +1,5 @@
+---
+'@jpmorganchase/mosaic-site-components': patch
+---
+
+Pass alt to Image if fill or width and height are not defined

--- a/packages/site-components/src/Image/index.tsx
+++ b/packages/site-components/src/Image/index.tsx
@@ -19,6 +19,7 @@ export type ImageProps = Omit<NextImageProps, 'src'> & {
 export const Image: FC<ImageProps> = forwardRef(
   (
     {
+      alt,
       className,
       nextImageClassName,
       src,
@@ -35,6 +36,7 @@ export const Image: FC<ImageProps> = forwardRef(
       <div className={classnames(styles.root, className)} ref={ref}>
         {fill || (width && height) ? (
           <NextImage
+            alt={alt}
             className={classnames(styles.nextImage, nextImageClassName)}
             {...rest}
             height={height}
@@ -45,6 +47,7 @@ export const Image: FC<ImageProps> = forwardRef(
           />
         ) : (
           <img
+            alt={alt}
             className={styles.img}
             src={src.match(/^(http[s]?:)?\/{1,2}/) === null ? resolvedSrc : src}
           />


### PR DESCRIPTION
The alt text wasn't added when <Image /> was used without fill or width and height. 