### PR TITLE
Prevent duplication of search results content

### DIFF
--- a/packages/site-components/src/SearchInput/Results.tsx
+++ b/packages/site-components/src/SearchInput/Results.tsx
@@ -5,12 +5,7 @@ import { Caption6, P4, P6 } from '@jpmorganchase/mosaic-components';
 import { Highlighter } from '@salt-ds/lab';
 
 import styles from './styles.css';
-
-interface SearchResult {
-  title: string;
-  route: string;
-  content: string;
-}
+import type { SearchResult } from './searchUtils';
 
 export type SearchResults = SearchResult[];
 type SearchResultsListProps = {

--- a/packages/site-components/src/SearchInput/Results.tsx
+++ b/packages/site-components/src/SearchInput/Results.tsx
@@ -20,7 +20,7 @@ interface ResultListItemProps {
   onSelect: (result) => void;
 }
 
-const MAX_RESULTS = 10;
+const MAX_RESULTS = 6;
 
 function ResultListItem({ result, query, onSelect }: ResultListItemProps) {
   const [hovered, setHovered] = useState(false);

--- a/packages/site-components/src/SearchInput/__tests__/searchUtils.test.tsx
+++ b/packages/site-components/src/SearchInput/__tests__/searchUtils.test.tsx
@@ -1,0 +1,48 @@
+import { calculateBestIndex, getBestMatch } from '../searchUtils';
+import type { Index, Match } from '../searchUtils';
+
+describe('GIVEN a list of search results', () => {
+  describe('WHEN parsing match indices', () => {
+    const matches: Match[] = [
+      {
+        indices: [
+          [9, 11], // ∆ = 1
+          [17, 21], // ∆ = 4
+          [27, 29] // ∆ = 2
+        ],
+        key: 'content',
+        value: 'blah blah TE blah TERM blah TE blah blah'
+      },
+      {
+        indices: [
+          [4, 6], // ∆ = 2
+          [12, 14], // ∆ = 2
+          [20, 23] // ∆ = 3
+        ],
+        key: 'content',
+        value: 'blah TE blah TE blah TER blah.'
+      }
+    ];
+
+    test('THEN the largest index is chosen', () => {
+      const indices: Index[] = [
+        [71, 78], // ∆ = 7
+        [8, 13], // ∆ = 5
+        [48, 50], // ∆ = 2
+        [32, 54], // ∆ = 22 (This is the match with the largest ∆)
+        [68, 69], // ∆ = 1
+        [56, 57], // ∆ = 1
+        [53, 54] // ∆ = 1
+      ];
+      const result = calculateBestIndex([...indices]);
+      expect(result.index.length).toBe(2);
+      expect(result.index).toEqual(indices[3]);
+      expect(result.delta).toEqual(22);
+    });
+
+    test('AND the match with the largest index ∆ is chosen', () => {
+      const result = getBestMatch([...matches]);
+      expect(result).toEqual('blah blah TE blah TERM blah TE blah blah');
+    });
+  });
+});

--- a/packages/site-components/src/SearchInput/__tests__/searchUtils.test.tsx
+++ b/packages/site-components/src/SearchInput/__tests__/searchUtils.test.tsx
@@ -1,4 +1,4 @@
-import { calculateBestIndex, getBestMatch } from '../searchUtils';
+import { calculateBestIndex, getBestMatch, highlightMatch } from '../searchUtils';
 import type { Index, Match } from '../searchUtils';
 
 describe('GIVEN a list of search results', () => {
@@ -6,18 +6,18 @@ describe('GIVEN a list of search results', () => {
     const matches: Match[] = [
       {
         indices: [
-          [9, 11], // ∆ = 1
-          [17, 21], // ∆ = 4
-          [27, 29] // ∆ = 2
+          [10, 11], // ∆ = 1
+          [18, 21], // ∆ = 3
+          [28, 29] // ∆ = 1
         ],
         key: 'content',
         value: 'blah blah TE blah TERM blah TE blah blah'
       },
       {
         indices: [
-          [4, 6], // ∆ = 2
-          [12, 14], // ∆ = 2
-          [20, 23] // ∆ = 3
+          [4, 5], // ∆ = 2
+          [12, 13], // ∆ = 2
+          [21, 23] // ∆ = 3
         ],
         key: 'content',
         value: 'blah TE blah TE blah TER blah.'
@@ -36,13 +36,51 @@ describe('GIVEN a list of search results', () => {
       ];
       const result = calculateBestIndex([...indices]);
       expect(result.index.length).toBe(2);
-      expect(result.index).toEqual(indices[3]);
+      expect(result.index).toEqual([32, 54]);
       expect(result.delta).toEqual(22);
     });
 
-    test('AND the match with the largest index ∆ is chosen', () => {
-      const result = getBestMatch([...matches]);
-      expect(result).toEqual('blah blah TE blah TERM blah TE blah blah');
+    test('AND the match with the largest index ∆ is chosen with highlighting applied', () => {
+      const result = getBestMatch([...matches], 'FALLBACK');
+      expect(result).toEqual('blah blah TE blah <strong>TERM</strong> blah TE blah blah');
+    });
+
+    test('AND matches from `title` and `route` are excluded to avoid duplication in the results display', () => {
+      const matchesWithTitle = [{ ...matches[0], key: 'title' }, matches[1]];
+      const result = getBestMatch([...matchesWithTitle], 'FALLBACK');
+      expect(result).toEqual('blah TE blah TE blah <strong>TER</strong> blah.');
+    });
+
+    test('AND if there are no unique matches, then fallback content will be shown with no highlighting applied', () => {
+      const matchesWithTitleAndRoute = [
+        { ...matches[0], key: 'title' },
+        { ...matches[1], key: 'route' }
+      ];
+      const result = getBestMatch([...matchesWithTitleAndRoute], 'FALLBACK');
+      expect(result).toEqual('FALLBACK');
+    });
+  });
+
+  describe('WHEN highlighting text', () => {
+    const exampleText = 'lorem ipsum TARGET dolor sit amet';
+    test('THEN a strong tag is wrapped around the target section', () => {
+      const result = highlightMatch(exampleText, [12, 17]);
+      expect(result).toEqual('lorem ipsum <strong>TARGET</strong> dolor sit amet');
+    });
+    test('AND handles overflowing indices', () => {
+      const overflow = highlightMatch(exampleText, [12, 117]);
+      expect(overflow).toEqual('lorem ipsum <strong>TARGET dolor sit amet</strong>');
+
+      const underflow = highlightMatch(exampleText, [-12, 17]);
+      expect(underflow).toEqual('<strong>lorem ipsum TARGET</strong> dolor sit amet');
+    });
+
+    test('AND returns the orginal text when provided a nonsensical index', () => {
+      const positiveMiss = highlightMatch(exampleText, [112, 117]);
+      expect(positiveMiss).toEqual(exampleText);
+
+      const negativeMiss = highlightMatch(exampleText, [-12, -10]);
+      expect(negativeMiss).toEqual(exampleText);
     });
   });
 });

--- a/packages/site-components/src/SearchInput/searchUtils.ts
+++ b/packages/site-components/src/SearchInput/searchUtils.ts
@@ -1,19 +1,36 @@
 import Fuse from 'fuse.js';
 
-const calculateBestIndex = rawIndices => {
-  const sorted = rawIndices
+export type Index = [number, number];
+type BestIndex = {
+  index: Index;
+  delta: number;
+};
+export type Match = {
+  indices: Index[];
+  key: string;
+  value: string;
+};
+
+export type SearchResult = {
+  title: string;
+  route: string;
+  content: string;
+};
+
+export const calculateBestIndex = (indices: Index[]): BestIndex => {
+  const sorted = indices
     .sort((a, b) => {
       const aSize = Math.abs(a[0] - a[1]);
       const bSize = Math.abs(b[0] - b[1]);
       return aSize - bSize;
     })
     .reverse();
-  const indices = sorted[0];
-  const delta = Math.abs(indices[0] - indices[1]);
-  return { indices, delta };
+  const index = sorted[0];
+  const delta = Math.abs(index[0] - index[1]);
+  return { index, delta };
 };
 
-export const getBestMatch = matches => {
+export const getBestMatch = (matches: Match[]) => {
   const matchesWithIndex = matches
     .map(match => ({
       ...match,
@@ -21,26 +38,15 @@ export const getBestMatch = matches => {
     }))
     .sort((a, b) => a.bestIndex.delta - b.bestIndex.delta)
     .reverse();
-  return matchesWithIndex[0];
+  return matchesWithIndex[0].value;
 };
 
-export const highlightMatch = match => {
-  const { indices } = match.bestIndex;
-  const parts = [
-    match.value.substring(0, indices[0]),
-    match.value.substring(indices[0], indices[1] + 1),
-    match.value.substring(indices[1] + 1)
-  ];
-  return `${parts[0]}<strong>${parts[1]}</strong>${parts[2]}`;
-};
-
-export const parseSearchResults = results =>
+export const parseSearchResults = (results): SearchResult[] =>
   results.map(result => {
     const bestMatch = getBestMatch(result.matches);
-    const highlight = highlightMatch(bestMatch);
     return {
       title: result.item.title,
-      content: highlight,
+      content: bestMatch,
       route: result.item.route
     };
   });

--- a/packages/site-components/src/SearchInput/searchUtils.ts
+++ b/packages/site-components/src/SearchInput/searchUtils.ts
@@ -5,10 +5,21 @@ type BestIndex = {
   index: Index;
   delta: number;
 };
+
+/**
+ * A "match" as returned by Fuse.js
+ */
 export type Match = {
   indices: Index[];
   key: string;
   value: string;
+};
+
+/**
+ * A "match" as returned by Fuse.js, with the best index calculated
+ */
+export type InternalMatch = Match & {
+  bestIndex: BestIndex;
 };
 
 export type SearchResult = {
@@ -30,20 +41,46 @@ export const calculateBestIndex = (indices: Index[]): BestIndex => {
   return { index, delta };
 };
 
-export const getBestMatch = (matches: Match[]) => {
+/**
+ * Highlight a section of text with a <strong> tag
+ *
+ * This is required in addition to the Salt `<Hightlight>` component because
+ * the Fuse.js "matches" may include text that differs slightly from the original
+ * search term. For example, if the search term is "foo", the match may be "fool".
+ *
+ * @param text The full text
+ * @param index The start and end points of the target portion of the text
+ * */
+export const highlightMatch = (text: string, index: Index) => {
+  const parts = [
+    text.substring(0, index[0]),
+    text.substring(index[0], index[1] + 1),
+    text.substring(index[1] + 1)
+  ];
+  if (parts[1].length === 0) return text;
+  return `${parts[0]}<strong>${parts[1]}</strong>${parts[2]}`;
+};
+
+export const getBestMatch = (matches: Match[], fallback: string) => {
   const matchesWithIndex = matches
+    .filter(match => match.key !== 'title' && match.key !== 'route')
     .map(match => ({
       ...match,
       bestIndex: calculateBestIndex(match.indices)
     }))
     .sort((a, b) => a.bestIndex.delta - b.bestIndex.delta)
     .reverse();
-  return matchesWithIndex[0].value;
+  if (matchesWithIndex.length > 0 && matchesWithIndex[0].value.length > 0) {
+    const bestMatch = matchesWithIndex[0];
+    return highlightMatch(bestMatch.value, bestMatch.bestIndex.index);
+  }
+  return fallback;
 };
 
 export const parseSearchResults = (results): SearchResult[] =>
   results.map(result => {
-    const bestMatch = getBestMatch(result.matches);
+    const fallbackContent = result.item.content ? result.item.content[0] : result.title;
+    const bestMatch = getBestMatch(result.matches, fallbackContent);
     return {
       title: result.item.title,
       content: bestMatch,


### PR DESCRIPTION
When search results are displayed, they include the page route, the title of the page, and a one-line snippet of content.

When Fuse.js finds a match, it provides the line of content along with highlighting information (which characters should be bold). This is great when the "best match" on the page is part of the regular content, but leads to messy and confusing results when the best match is in either the title or route of the page: i.e. we get duplicated content being displayed, as well as *lower* information density (because we're losing the extra context provided by the one-line snippet.

This change makes search results snippet display the first line of the content when the "best match" is in the route or title (so a result will *always* include the route, title, and a useful text snippet).

<img width="590" alt="Screenshot 2023-04-18 at 13 02 43" src="https://user-images.githubusercontent.com/5412181/232774352-f4569e4d-4317-481e-bd5d-9d5910de2418.png">

---

This PR also includes:
* types and tests for search utils.
* Reduced number of results shown on screen at any one time (`10` was overflowing the page on smaller screens. `6` feels more sensible)