### PR TITLE
TOC Indentation

### DIFF
--- a/packages/site-components/src/TableOfContents/TableOfContents.tsx
+++ b/packages/site-components/src/TableOfContents/TableOfContents.tsx
@@ -21,7 +21,7 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({ items }) => {
     throw new Error('No `items` specified for Table of Contents.');
   }
 
-  const headingsRef = useRef<CurrentItem[]>(setupHeadingState(items));
+  const headingsRef = useRef<CurrentItem[]>(setupHeadingState());
   const [selectedHeading, setSelectedHeading] = useState(() =>
     setupSelectedHeadingState(headingsRef.current)
   );
@@ -85,7 +85,7 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({ items }) => {
   }, [size.width, size.height]);
 
   useEffect(() => {
-    const newHeadings = setupHeadingState(items);
+    const newHeadings = setupHeadingState();
     headingsRef.current = newHeadings;
     if (headingPositions.current.length !== items.length) {
       matchHeadingsToDOM();

--- a/packages/site-components/src/TableOfContents/TableOfContentsItem.tsx
+++ b/packages/site-components/src/TableOfContents/TableOfContentsItem.tsx
@@ -31,7 +31,7 @@ export function TableOfContentsItem({ item, current }) {
       aria-checked={selected}
       aria-label={item.text}
       aria-level={1}
-      className={classnames(styles.item)}
+      className={classnames(styles.item, styles[`level${item.level}`])}
       data-selected={!!selected}
       onClick={handleItemClick}
       tabIndex={-1}

--- a/packages/site-components/src/TableOfContents/__tests__/utils.test.tsx
+++ b/packages/site-components/src/TableOfContents/__tests__/utils.test.tsx
@@ -24,9 +24,33 @@ describe('GIVEN a Table Of Contents (TOC)', () => {
 
   describe('WHEN loading a new page', () => {
     test('THEN the initial TOC heading state is created', () => {
-      expect(setupHeadingState([{ item: 1 }, { item: 2 }])).toEqual([
-        { item: 1, current: false },
-        { item: 2, current: false }
+      document.body.innerHTML = `
+            <h1 id="heading-1">Heading 1</h1>
+            <h2 id="heading-2">Heading 2</h2>
+            <h3 id="heading-3">Heading 3</h3>
+          `;
+
+      const result = setupHeadingState();
+
+      expect(result).toEqual([
+        {
+          id: 'heading-1',
+          level: 1,
+          text: 'Heading 1',
+          current: false
+        },
+        {
+          id: 'heading-2',
+          level: 2,
+          text: 'Heading 2',
+          current: false
+        },
+        {
+          id: 'heading-3',
+          level: 3,
+          text: 'Heading 3',
+          current: false
+        }
       ]);
     });
     test('THEN the initial TOC selected state is created', () => {

--- a/packages/site-components/src/TableOfContents/styles.css.ts
+++ b/packages/site-components/src/TableOfContents/styles.css.ts
@@ -32,10 +32,21 @@ export default {
     }),
     link({ variant: 'selectable' }),
     responsiveSprinkles({
-      paddingTop: ['x2', 'x2', 'x2', 'x2'],
+      paddingTop: ['x1', 'x1', 'x1', 'x1'],
       paddingRight: ['x4', 'x4', 'x4', 'x4'],
-      paddingBottom: ['x2', 'x2', 'x2', 'x2'],
-      paddingLeft: ['x4', 'x4', 'x4', 'x4']
+      paddingBottom: ['x1', 'x1', 'x1', 'x1']
     })
-  ])
+  ]),
+  level1: responsiveSprinkles({
+    paddingLeft: ['x2', 'x2', 'x2', 'x2']
+  }),
+  level2: responsiveSprinkles({
+    paddingLeft: ['x4', 'x4', 'x4', 'x4']
+  }),
+  level3: responsiveSprinkles({
+    paddingLeft: ['x6', 'x6', 'x6', 'x6']
+  }),
+  level4: responsiveSprinkles({
+    paddingLeft: ['x8', 'x8', 'x8', 'x8']
+  })
 };

--- a/packages/site-components/src/TableOfContents/utils.tsx
+++ b/packages/site-components/src/TableOfContents/utils.tsx
@@ -1,4 +1,4 @@
-import type { CurrentItem, Item } from './TableOfContents';
+import type { CurrentItem } from './TableOfContents';
 
 export const mostRecentScrollPoint = (scrollPosition, allPositions) => {
   const validPositions = allPositions.filter(i => typeof i === 'number');
@@ -19,7 +19,14 @@ export const mostRecentScrollPoint = (scrollPosition, allPositions) => {
 
 export const stripMarkdownLinks = text => text.replace(/\[([^[\]]*)\]\((.*?)\)/gm, '$1');
 
-export const setupHeadingState: (items?: Item[]) => CurrentItem[] = (items = []) =>
-  items.map(item => ({ ...item, current: false }));
+export const setupHeadingState = (): CurrentItem[] => {
+  const headingElements = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6'));
+  return headingElements.map((element, index) => ({
+    id: element.id || `toc-heading-${index}`,
+    level: Number(element.tagName.slice(1)),
+    text: element.textContent || '',
+    current: false
+  }));
+};
 
 export const setupSelectedHeadingState = headings => (headings.length > 0 ? headings[0].slug : '');

--- a/packages/site/snapshots/latest/mosaic/author/aliases.mdx
+++ b/packages/site/snapshots/latest/mosaic/author/aliases.mdx
@@ -22,7 +22,7 @@ sharedConfig:
     description: Coming soon
     title: Mosaic BETA
     href: /mosaic
-lastModified: 1680621246332
+lastModified: 1680534781742
 fullPath: /mosaic/author/aliases.mdx
 route: /mosaic/author/aliases
 breadcrumbs:
@@ -41,9 +41,6 @@ readingTime:
   time: 31500
   words: 105
 tableOfContents:
-  - level: 1
-    id: aliases
-    text: Aliases
   - level: 2
     id: use-cases
     text: Use Cases

--- a/packages/site/snapshots/latest/mosaic/author/frontmatter.mdx
+++ b/packages/site/snapshots/latest/mosaic/author/frontmatter.mdx
@@ -3,7 +3,7 @@ title: Frontmatter
 layout: DetailTechnical
 sidebar:
   priority: 4
-lastModified: 1681467393997
+lastModified: 1681297655932
 fullPath: /mosaic/author/frontmatter.mdx
 route: /mosaic/author/frontmatter
 breadcrumbs:
@@ -22,9 +22,6 @@ readingTime:
   time: 132900
   words: 443
 tableOfContents:
-  - level: 1
-    id: frontmatter
-    text: Frontmatter
   - level: 2
     id: example-page-yaml
     text: Example page yaml

--- a/packages/site/snapshots/latest/mosaic/author/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/author/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   priority: 3
 data:
   exampleRefData: Hello from Author page
-lastModified: 1681467393998
+lastModified: 1681403319892
 fullPath: /mosaic/author/index.mdx
 route: /mosaic/author/index
 breadcrumbs:
@@ -20,10 +20,7 @@ readingTime:
   minutes: 0.075
   time: 4500
   words: 15
-tableOfContents:
-  - level: 1
-    id: author
-    text: Author
+tableOfContents: []
 navigation:
   next:
     title: Markdown Syntax

--- a/packages/site/snapshots/latest/mosaic/author/markdown-syntax.mdx
+++ b/packages/site/snapshots/latest/mosaic/author/markdown-syntax.mdx
@@ -3,7 +3,7 @@ title: Markdown Syntax
 layout: DetailTechnical
 sidebar:
   priority: 5
-lastModified: 1681467393998
+lastModified: 1681297655933
 fullPath: /mosaic/author/markdown-syntax.mdx
 route: /mosaic/author/markdown-syntax
 breadcrumbs:
@@ -22,9 +22,6 @@ readingTime:
   time: 30300
   words: 101
 tableOfContents:
-  - level: 1
-    id: markdown-syntax
-    text: Markdown Syntax
   - level: 2
     id: mosaic-standard-components
     text: Mosaic Standard Components

--- a/packages/site/snapshots/latest/mosaic/author/page-templates.mdx
+++ b/packages/site/snapshots/latest/mosaic/author/page-templates.mdx
@@ -3,7 +3,7 @@ title: Page Templates
 layout: DetailTechnical
 sidebar:
   priority: 1
-lastModified: 1680621246332
+lastModified: 1681743765084
 fullPath: /mosaic/author/page-templates.mdx
 route: /mosaic/author/page-templates
 breadcrumbs:
@@ -21,10 +21,7 @@ readingTime:
   minutes: 0.005
   time: 300
   words: 1
-tableOfContents:
-  - level: 1
-    id: page-templates
-    text: Page Templates
+tableOfContents: []
 navigation:
   prev:
     title: UI Components

--- a/packages/site/snapshots/latest/mosaic/author/refs.mdx
+++ b/packages/site/snapshots/latest/mosaic/author/refs.mdx
@@ -10,7 +10,7 @@ data:
     - Snapshot file mode
     - Snapshot AWS/S3 mode
   sidebarPriority: 3
-lastModified: 1681467393998
+lastModified: 1681297655934
 fullPath: /mosaic/author/refs.mdx
 route: /mosaic/author/refs
 breadcrumbs:
@@ -29,9 +29,6 @@ readingTime:
   time: 184800
   words: 616
 tableOfContents:
-  - level: 1
-    id: refs
-    text: Refs
   - level: 2
     id: local-refs-in-schema-reference
     text: Local refs (In-schema reference)

--- a/packages/site/snapshots/latest/mosaic/author/ui-components.mdx
+++ b/packages/site/snapshots/latest/mosaic/author/ui-components.mdx
@@ -3,7 +3,7 @@ title: UI Components
 layout: DetailTechnical
 sidebar:
   priority: 2
-lastModified: 1680621246332
+lastModified: 1681985114198
 fullPath: /mosaic/author/ui-components.mdx
 route: /mosaic/author/ui-components
 breadcrumbs:
@@ -21,10 +21,7 @@ readingTime:
   minutes: 0.005
   time: 300
   words: 1
-tableOfContents:
-  - level: 1
-    id: ui-components
-    text: UI Components
+tableOfContents: []
 navigation:
   prev:
     title: Refs

--- a/packages/site/snapshots/latest/mosaic/configure/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/index.mdx
@@ -3,7 +3,7 @@ title: Configure
 layout: DetailTechnical
 sidebar:
   priority: 4
-lastModified: 1680621246332
+lastModified: 1680534781747
 fullPath: /mosaic/configure/index.mdx
 route: /mosaic/configure/index
 breadcrumbs:
@@ -18,10 +18,7 @@ readingTime:
   minutes: 0.19
   time: 11400
   words: 38
-tableOfContents:
-  - level: 1
-    id: configure
-    text: Configure
+tableOfContents: []
 navigation:
   next:
     title: Modes of operation

--- a/packages/site/snapshots/latest/mosaic/configure/layouts/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/layouts/index.mdx
@@ -3,7 +3,7 @@ title: Layouts
 layout: DetailTechnical
 sidebar:
   priority: 2
-lastModified: 1680621246332
+lastModified: 1680774877382
 fullPath: /mosaic/configure/layouts/index.mdx
 route: /mosaic/configure/layouts/index
 breadcrumbs:
@@ -21,10 +21,7 @@ readingTime:
   minutes: 0.005
   time: 300
   words: 1
-tableOfContents:
-  - level: 1
-    id: layouts
-    text: Layouts
+tableOfContents: []
 navigation:
   prev:
     title: HTTP Source

--- a/packages/site/snapshots/latest/mosaic/configure/modes/active.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/modes/active.mdx
@@ -1,7 +1,7 @@
 ---
 title: Active mode
 layout: DetailTechnical
-lastModified: 1680621246333
+lastModified: 1680534781750
 fullPath: /mosaic/configure/modes/active.mdx
 route: /mosaic/configure/modes/active
 breadcrumbs:
@@ -23,9 +23,6 @@ readingTime:
   time: 58500
   words: 195
 tableOfContents:
-  - level: 1
-    id: active-mode
-    text: Active mode
   - level: 2
     id: configuring-your-content-sources
     text: Configuring your content sources

--- a/packages/site/snapshots/latest/mosaic/configure/modes/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/modes/index.mdx
@@ -8,7 +8,7 @@ data:
     - Active mode
     - Snapshot file mode
     - Snapshot AWS/S3 mode
-lastModified: 1681467393998
+lastModified: 1681297655934
 fullPath: /mosaic/configure/modes/index.mdx
 route: /mosaic/configure/modes/index
 breadcrumbs:
@@ -27,9 +27,6 @@ readingTime:
   time: 29100
   words: 97
 tableOfContents:
-  - level: 1
-    id: modes-of-operation
-    text: Modes of operation
   - level: 2
     id: active-updates
     text: Active updates

--- a/packages/site/snapshots/latest/mosaic/configure/modes/snapshot-file.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/modes/snapshot-file.mdx
@@ -1,7 +1,7 @@
 ---
 title: Snapshot file mode
 layout: DetailTechnical
-lastModified: 1680621246333
+lastModified: 1680534781750
 fullPath: /mosaic/configure/modes/snapshot-file.mdx
 route: /mosaic/configure/modes/snapshot-file
 breadcrumbs:
@@ -23,9 +23,6 @@ readingTime:
   time: 19200
   words: 64
 tableOfContents:
-  - level: 1
-    id: snapshot-file-mode
-    text: Snapshot file mode
   - level: 2
     id: generating-a-snapshot
     text: Generating a snapshot

--- a/packages/site/snapshots/latest/mosaic/configure/modes/snapshot-s3.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/modes/snapshot-s3.mdx
@@ -1,7 +1,7 @@
 ---
 title: Snapshot AWS/S3 mode
 layout: DetailTechnical
-lastModified: 1680621246333
+lastModified: 1680534781751
 fullPath: /mosaic/configure/modes/snapshot-s3.mdx
 route: /mosaic/configure/modes/snapshot-s3
 breadcrumbs:
@@ -23,9 +23,6 @@ readingTime:
   time: 20100
   words: 67
 tableOfContents:
-  - level: 1
-    id: snapshot-awss3-mode
-    text: Snapshot AWS/S3 mode
   - level: 2
     id: generating-a-snapshot
     text: Generating a snapshot

--- a/packages/site/snapshots/latest/mosaic/configure/plugins/after-source.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/plugins/after-source.mdx
@@ -3,7 +3,7 @@ title: $afterSource
 layout: DetailOverview
 sidebar:
   label: Lifecycle - $afterSource
-lastModified: 1680621246333
+lastModified: 1680534781751
 fullPath: /mosaic/configure/plugins/after-source.mdx
 route: /mosaic/configure/plugins/after-source
 breadcrumbs:
@@ -25,9 +25,6 @@ readingTime:
   time: 54600
   words: 182
 tableOfContents:
-  - level: 1
-    id: aftersource
-    text: $afterSource
   - level: 2
     id: helpers
     text: Helpers

--- a/packages/site/snapshots/latest/mosaic/configure/plugins/after-update.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/plugins/after-update.mdx
@@ -3,7 +3,7 @@ title: afterUpdate
 layout: DetailOverview
 sidebar:
   label: Lifecycle - afterUpdate
-lastModified: 1680621246333
+lastModified: 1680534781751
 fullPath: /mosaic/configure/plugins/after-update.mdx
 route: /mosaic/configure/plugins/after-update
 breadcrumbs:
@@ -25,9 +25,6 @@ readingTime:
   time: 20700
   words: 69
 tableOfContents:
-  - level: 1
-    id: afterupdate
-    text: afterUpdate
   - level: 2
     id: todo
     text: Todo

--- a/packages/site/snapshots/latest/mosaic/configure/plugins/before-send.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/plugins/before-send.mdx
@@ -3,7 +3,7 @@ title: $beforeSend
 layout: DetailOverview
 sidebar:
   label: Lifecycle - $beforeSend
-lastModified: 1680621246333
+lastModified: 1680534781752
 fullPath: /mosaic/configure/plugins/before-send.mdx
 route: /mosaic/configure/plugins/before-send
 breadcrumbs:
@@ -25,9 +25,6 @@ readingTime:
   time: 8100
   words: 27
 tableOfContents:
-  - level: 1
-    id: beforesend
-    text: $beforeSend
   - level: 2
     id: todo
     text: Todo

--- a/packages/site/snapshots/latest/mosaic/configure/plugins/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/plugins/index.mdx
@@ -3,7 +3,7 @@ title: Plugins
 layout: DetailTechnical
 sidebar:
   priority: 1
-lastModified: 1680621246333
+lastModified: 1680534781753
 fullPath: /mosaic/configure/plugins/index.mdx
 route: /mosaic/configure/plugins/index
 breadcrumbs:
@@ -22,9 +22,6 @@ readingTime:
   time: 98100
   words: 327
 tableOfContents:
-  - level: 1
-    id: plugins
-    text: Plugins
   - level: 2
     id: installation
     text: Installation

--- a/packages/site/snapshots/latest/mosaic/configure/plugins/should-clear-cache.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/plugins/should-clear-cache.mdx
@@ -3,7 +3,7 @@ title: shouldClearCache
 layout: DetailOverview
 sidebar:
   label: Lifecycle - shouldClearCache
-lastModified: 1680621246333
+lastModified: 1680534781753
 fullPath: /mosaic/configure/plugins/should-clear-cache.mdx
 route: /mosaic/configure/plugins/should-clear-cache
 breadcrumbs:
@@ -25,9 +25,6 @@ readingTime:
   time: 12300
   words: 41
 tableOfContents:
-  - level: 1
-    id: shouldclearcache
-    text: shouldClearCache
   - level: 2
     id: todo
     text: Todo

--- a/packages/site/snapshots/latest/mosaic/configure/sources/git-repo-source.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/sources/git-repo-source.mdx
@@ -3,7 +3,7 @@ title: Git Repo Source
 layout: DetailTechnical
 sidebar:
   priority: 2
-lastModified: 1680621246333
+lastModified: 1680534781754
 fullPath: /mosaic/configure/sources/git-repo-source.mdx
 route: /mosaic/configure/sources/git-repo-source
 breadcrumbs:
@@ -25,9 +25,6 @@ readingTime:
   time: 78600
   words: 262
 tableOfContents:
-  - level: 1
-    id: git-repo-source
-    text: Git Repo Source
   - level: 2
     id: installation
     text: Installation

--- a/packages/site/snapshots/latest/mosaic/configure/sources/http-source.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/sources/http-source.mdx
@@ -3,7 +3,7 @@ title: HTTP Source
 layout: DetailTechnical
 sidebar:
   priority: 1
-lastModified: 1680621246333
+lastModified: 1680534781755
 fullPath: /mosaic/configure/sources/http-source.mdx
 route: /mosaic/configure/sources/http-source
 breadcrumbs:
@@ -25,9 +25,6 @@ readingTime:
   time: 55200
   words: 184
 tableOfContents:
-  - level: 1
-    id: http-source
-    text: HTTP Source
   - level: 2
     id: installation
     text: Installation

--- a/packages/site/snapshots/latest/mosaic/configure/sources/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/sources/index.mdx
@@ -3,7 +3,7 @@ title: Sources
 layout: DetailTechnical
 sidebar:
   priority: 3
-lastModified: 1680621246334
+lastModified: 1680534781755
 fullPath: /mosaic/configure/sources/index.mdx
 route: /mosaic/configure/sources/index
 breadcrumbs:
@@ -22,9 +22,6 @@ readingTime:
   time: 136200
   words: 454
 tableOfContents:
-  - level: 1
-    id: sources
-    text: Sources
   - level: 2
     id: source-definitions
     text: Source Definitions

--- a/packages/site/snapshots/latest/mosaic/configure/sources/local-folder-source.mdx
+++ b/packages/site/snapshots/latest/mosaic/configure/sources/local-folder-source.mdx
@@ -3,7 +3,7 @@ title: Local Folder Source
 layout: DetailTechnical
 sidebar:
   priority: 3
-lastModified: 1680621246334
+lastModified: 1680534781755
 fullPath: /mosaic/configure/sources/local-folder-source.mdx
 route: /mosaic/configure/sources/local-folder-source
 breadcrumbs:
@@ -25,9 +25,6 @@ readingTime:
   time: 70800
   words: 236
 tableOfContents:
-  - level: 1
-    id: local-folder-source
-    text: Local Folder Source
   - level: 2
     id: installation
     text: Installation

--- a/packages/site/snapshots/latest/mosaic/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/index.mdx
@@ -20,7 +20,7 @@ sharedConfig:
     description: Coming soon
     title: Mosaic BETA
     href: /mosaic
-lastModified: 1680621246334
+lastModified: 1681743765085
 fullPath: /mosaic/index.mdx
 route: /mosaic/index
 readingTime:

--- a/packages/site/snapshots/latest/mosaic/publish/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/publish/index.mdx
@@ -3,7 +3,7 @@ title: Publish
 layout: DetailTechnical
 sidebar:
   priority: 2
-lastModified: 1680621246334
+lastModified: 1680534781757
 fullPath: /mosaic/publish/index.mdx
 route: /mosaic/publish/index
 breadcrumbs:
@@ -19,9 +19,6 @@ readingTime:
   time: 45300
   words: 151
 tableOfContents:
-  - level: 1
-    id: publish
-    text: Publish
   - level: 2
     id: create-your-first-site
     text: Create your first site

--- a/packages/site/snapshots/latest/mosaic/publish/publish-site-to-aws.mdx
+++ b/packages/site/snapshots/latest/mosaic/publish/publish-site-to-aws.mdx
@@ -1,7 +1,7 @@
 ---
 title: Publish a site to AWS
 layout: DetailTechnical
-lastModified: 1680621246334
+lastModified: 1680534781758
 fullPath: /mosaic/publish/publish-site-to-aws.mdx
 route: /mosaic/publish/publish-site-to-aws
 breadcrumbs:
@@ -19,10 +19,7 @@ readingTime:
   minutes: 0.52
   time: 31200
   words: 104
-tableOfContents:
-  - level: 1
-    id: publish-a-site-to-aws
-    text: Publish a site to AWS
+tableOfContents: []
 navigation:
   next:
     title: Publish a site to Vercel

--- a/packages/site/snapshots/latest/mosaic/publish/publish-site-to-vercel.mdx
+++ b/packages/site/snapshots/latest/mosaic/publish/publish-site-to-vercel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Publish a site to Vercel
 layout: DetailTechnical
-lastModified: 1680621246334
+lastModified: 1680534781758
 fullPath: /mosaic/publish/publish-site-to-vercel.mdx
 route: /mosaic/publish/publish-site-to-vercel
 breadcrumbs:
@@ -20,9 +20,6 @@ readingTime:
   time: 59400
   words: 198
 tableOfContents:
-  - level: 1
-    id: publish-a-site-to-vercel
-    text: Publish a site to Vercel
   - level: 2
     id: deployment
     text: Deployment

--- a/packages/site/snapshots/latest/mosaic/quick-start/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/quick-start/index.mdx
@@ -3,7 +3,7 @@ title: Quick start guides
 layout: DetailTechnical
 sidebar:
   priority: 5
-lastModified: 1680621246334
+lastModified: 1680534781759
 fullPath: /mosaic/quick-start/index.mdx
 route: /mosaic/quick-start/index
 breadcrumbs:
@@ -18,10 +18,7 @@ readingTime:
   minutes: 0.04
   time: 2400
   words: 8
-tableOfContents:
-  - level: 1
-    id: quick-start-guides
-    text: Quick start guides
+tableOfContents: []
 navigation:
   next:
     title: Publish a site to AWS

--- a/packages/site/snapshots/latest/mosaic/quick-start/publish-site-to-aws.mdx
+++ b/packages/site/snapshots/latest/mosaic/quick-start/publish-site-to-aws.mdx
@@ -1,7 +1,7 @@
 ---
 title: Publish a site to AWS
 layout: DetailTechnical
-lastModified: 1680164438088
+lastModified: 1677168430264
 fullPath: /mosaic/quick-start/publish-site-to-aws.mdx
 route: /mosaic/quick-start/publish-site-to-aws
 breadcrumbs:
@@ -20,9 +20,6 @@ readingTime:
   time: 63900
   words: 213
 tableOfContents:
-  - level: 1
-    id: publish-a-site-to-aws
-    text: Publish a site to AWS
   - level: 2
     id: step-1-generate-a-mosaic-site
     text: 'Step 1: Generate a Mosaic site'

--- a/packages/site/snapshots/latest/mosaic/test/aliases/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/aliases/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aliases Test
 layout: FullWidth
-lastModified: 1681467393998
+lastModified: 1681297655934
 fullPath: /mosaic/test/aliases/index.mdx
 route: /mosaic/test/aliases/index
 readingTime:
@@ -9,10 +9,7 @@ readingTime:
   minutes: 0.035
   time: 2100
   words: 7
-tableOfContents:
-  - level: 1
-    id: aliases-test
-    text: Aliases Test
+tableOfContents: []
 navigation:
   prev:
     title: Refs Data

--- a/packages/site/snapshots/latest/mosaic/test/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/index.mdx
@@ -3,7 +3,7 @@ title: Test
 layout: DetailTechnical
 sidebar:
   priority: 3
-lastModified: 1681467393998
+lastModified: 1680627114164
 fullPath: /mosaic/test/index.mdx
 route: /mosaic/test/index
 breadcrumbs:
@@ -18,10 +18,7 @@ readingTime:
   minutes: 0.02
   time: 1200
   words: 4
-tableOfContents:
-  - level: 1
-    id: test
-    text: Test
+tableOfContents: []
 navigation:
   next:
     title: Layouts

--- a/packages/site/snapshots/latest/mosaic/test/layouts/detail-highlight.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/layouts/detail-highlight.mdx
@@ -33,7 +33,7 @@ navigation:
   next:
     title: Detail Overview Test Page
     route: /mosaic/test/layouts/detail-overview
-lastModified: 1680164438088
+lastModified: 1679911153406
 fullPath: /mosaic/test/layouts/detail-highlight.mdx
 route: /mosaic/test/layouts/detail-highlight
 sharedConfig: *ref_0

--- a/packages/site/snapshots/latest/mosaic/test/layouts/detail-overview.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/layouts/detail-overview.mdx
@@ -33,7 +33,7 @@ navigation:
   next:
     title: Detail Technical Test Page
     route: /mosaic/test/layouts/detail-technical
-lastModified: 1680164438088
+lastModified: 1680182675961
 fullPath: /mosaic/test/layouts/detail-overview.mdx
 route: /mosaic/test/layouts/detail-overview
 sharedConfig: *ref_0

--- a/packages/site/snapshots/latest/mosaic/test/layouts/detail-technical.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/layouts/detail-technical.mdx
@@ -33,7 +33,7 @@ navigation:
   next:
     title: Edit Layout
     route: /mosaic/test/layouts/edit
-lastModified: 1680164438088
+lastModified: 1680182675962
 fullPath: /mosaic/test/layouts/detail-technical.mdx
 route: /mosaic/test/layouts/detail-technical
 sharedConfig: *ref_0

--- a/packages/site/snapshots/latest/mosaic/test/layouts/edit.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/layouts/edit.mdx
@@ -33,7 +33,7 @@ navigation:
   next:
     title: Full Width Layout
     route: /mosaic/test/layouts/full-width
-lastModified: 1680164438088
+lastModified: 1679911153407
 fullPath: /mosaic/test/layouts/edit.mdx
 route: /mosaic/test/layouts/edit
 sharedConfig: *ref_0

--- a/packages/site/snapshots/latest/mosaic/test/layouts/full-width.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/layouts/full-width.mdx
@@ -33,7 +33,7 @@ navigation:
   next:
     title: Landing Layout Test Page
     route: /mosaic/test/layouts/landing
-lastModified: 1680164438088
+lastModified: 1679911153408
 fullPath: /mosaic/test/layouts/full-width.mdx
 route: /mosaic/test/layouts/full-width
 sharedConfig: *ref_0

--- a/packages/site/snapshots/latest/mosaic/test/layouts/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/layouts/index.mdx
@@ -3,7 +3,7 @@ title: Layouts
 layout: DetailTechnical
 sidebar:
   priority: 3
-lastModified: 1681467393998
+lastModified: 1680627114165
 fullPath: /mosaic/test/layouts/index.mdx
 route: /mosaic/test/layouts/index
 breadcrumbs:
@@ -21,10 +21,7 @@ readingTime:
   minutes: 0.03
   time: 1800
   words: 6
-tableOfContents:
-  - level: 1
-    id: layouts
-    text: Layouts
+tableOfContents: []
 navigation:
   next:
     title: Detail Highlight Test Page

--- a/packages/site/snapshots/latest/mosaic/test/layouts/landing.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/layouts/landing.mdx
@@ -16,7 +16,7 @@ frameOverrides: &ref_0
     description: Footer Content
     title: Landing Layout Footer
     href: /mosaic
-lastModified: 1680164438089
+lastModified: 1679911153408
 fullPath: /mosaic/test/layouts/landing.mdx
 route: /mosaic/test/layouts/landing
 sharedConfig: *ref_0

--- a/packages/site/snapshots/latest/mosaic/test/layouts/newsletter.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/layouts/newsletter.mdx
@@ -33,7 +33,7 @@ navigation:
   next:
     title: Product Discover Test Page
     route: /mosaic/test/layouts/product-discover
-lastModified: 1680164438089
+lastModified: 1679911153408
 fullPath: /mosaic/test/layouts/newsletter.mdx
 route: /mosaic/test/layouts/newsletter
 sharedConfig: *ref_0

--- a/packages/site/snapshots/latest/mosaic/test/layouts/product-discover.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/layouts/product-discover.mdx
@@ -33,7 +33,7 @@ navigation:
   next:
     title: Product Preview Test Page
     route: /mosaic/test/layouts/product-preview
-lastModified: 1680164438089
+lastModified: 1679911153409
 fullPath: /mosaic/test/layouts/product-discover.mdx
 route: /mosaic/test/layouts/product-discover
 sharedConfig: *ref_0

--- a/packages/site/snapshots/latest/mosaic/test/layouts/product-preview.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/layouts/product-preview.mdx
@@ -16,7 +16,7 @@ frameOverrides: &ref_0
     description: Footer Content
     title: Product Preview Layout Footer
     href: /mosaic
-lastModified: 1680164438089
+lastModified: 1679911153409
 fullPath: /mosaic/test/layouts/product-preview.mdx
 route: /mosaic/test/layouts/product-preview
 sharedConfig: *ref_0

--- a/packages/site/snapshots/latest/mosaic/test/refs/data.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/refs/data.mdx
@@ -2,7 +2,7 @@
 title: Refs Data
 data:
   randomValue: 100
-lastModified: 1681467393998
+lastModified: 1681297655935
 fullPath: /mosaic/test/refs/data.mdx
 route: /mosaic/test/refs/data
 readingTime:

--- a/packages/site/snapshots/latest/mosaic/test/refs/index.mdx
+++ b/packages/site/snapshots/latest/mosaic/test/refs/index.mdx
@@ -6,7 +6,7 @@ sidebar:
 data:
   other: 100
   sidebarPriority: 3
-lastModified: 1681467393999
+lastModified: 1681297655936
 fullPath: /mosaic/test/refs/index.mdx
 route: /mosaic/test/refs/index
 readingTime:
@@ -14,10 +14,7 @@ readingTime:
   minutes: 0.05
   time: 3000
   words: 10
-tableOfContents:
-  - level: 1
-    id: refs-test
-    text: Refs Test
+tableOfContents: []
 navigation:
   prev:
     title: Product Preview Test Page

--- a/packages/standard-generator/src/fs.config.js
+++ b/packages/standard-generator/src/fs.config.js
@@ -78,7 +78,7 @@ module.exports = {
     {
       modulePath: '@jpmorganchase/mosaic-plugins/TableOfContentsPlugin',
       options: {
-        minRank: 1,
+        minRank: 2,
         maxRank: 3
       }
     }


### PR DESCRIPTION
This PR contains 5 commits corresponding to changes to the TOC.

1. Styling has been added so that TOC items are indented depending on the level of the heading.

2. The TOC plugin's minRank and maxRank have been updated to exclude H1s. This change was made because when the indentation was added, it became apparent that the H1 serves as the title of the page rather than part of its contents. Including it made the indentation look unusual when everything was nested under it.

3. Fix TOC item highlighting by including all headings in the page when finding the current heading. Prior to this fix, the highlighting was broken and did not correspond to the correct heading in the TOC. This was due to headings being removed from the TOC, which revealed the issue.

4. Update the snapshot. 

5. Change setupHeadingState test to reflect the change made in point 3 above.