### PR TITLE
fix: hide images when SSR class is applied

### DIFF
--- a/.changeset/curly-apes-pay.md
+++ b/.changeset/curly-apes-pay.md
@@ -1,0 +1,7 @@
+---
+'@jpmorganchase/mosaic-components': patch
+'@jpmorganchase/mosaic-site': patch
+'@jpmorganchase/mosaic-theme': patch
+---
+
+Fix: hide `img` and `svg` in SSR content to prevent massive images caused by lack of Salt styles

--- a/packages/components/src/ThemeProvider.tsx
+++ b/packages/components/src/ThemeProvider.tsx
@@ -1,6 +1,9 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 import { SaltProvider } from '@salt-ds/core';
 import { useColorMode } from '@jpmorganchase/mosaic-store';
+import { ssrClassName } from '@jpmorganchase/mosaic-theme';
+
+import classnames from 'clsx';
 
 const useHasHydrated = () => {
   const [hasHydrated, setHasHydrated] = useState(false);
@@ -21,9 +24,11 @@ export function ThemeProvider({ className, children }: ThemeProviderProps) {
   const hasHydrated = useHasHydrated();
   const colorMode = useColorMode();
 
+  const ssrClassname = hasHydrated ? undefined : ssrClassName;
+
   return (
     <SaltProvider applyClassesTo="child" mode={hasHydrated ? colorMode : 'light'}>
-      <div className={className}>
+      <div className={classnames(ssrClassname, className)}>
         {children}
         <div data-mosaic-id="portal-root" />
       </div>

--- a/packages/theme/src/baseline/baseline.css.ts
+++ b/packages/theme/src/baseline/baseline.css.ts
@@ -1,4 +1,5 @@
 import { globalStyle } from '@vanilla-extract/css';
+import { ssrClassName } from '../index';
 
 globalStyle('html, body', {
   fontFamily: 'Open Sans',
@@ -42,4 +43,8 @@ globalStyle('h1, h2, h3, h4, h5, h6', {
 
 globalStyle('li > p', {
   display: 'inline'
+});
+
+globalStyle(`.${ssrClassName} svg, .${ssrClassName} img`, {
+  display: 'none'
 });

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -11,6 +11,7 @@ import {
 import { shadow } from './shadow';
 import { vars } from './vars.css';
 
+export const ssrClassName = 'mosaic-ssr';
 export { themeClassName, vars } from './vars.css';
 export * from './animation';
 export * from './blockquote';


### PR DESCRIPTION
style-inject is used by salt to insert styles.  This doesn't support SSR --> https://github.com/egoist/style-inject/blob/master/src/index.js#L2

So the styling that prevents images and icons from being huge is not applied.

This change adds a class before hydration that hides `img` and `svg` elements.


### WARNING:

This change dropped the Lighthouse perf metric from 98 down to 86.  I don't know if this is because it was being checked on a vercel preview branch rather than the main prod branch or if the change is the issue.

