### PR TITLE
Dynamically add a source

### DIFF
--- a/.changeset/dull-carrots-drive.md
+++ b/.changeset/dull-carrots-drive.md
@@ -1,0 +1,49 @@
+---
+'@jpmorganchase/mosaic-cli': patch
+'@jpmorganchase/mosaic-core': patch
+'@jpmorganchase/mosaic-schemas': patch
+'@jpmorganchase/mosaic-site': patch
+'@jpmorganchase/mosaic-standard-generator': patch
+---
+
+## Source Pushing
+
+The Mosaic CLI provides an endpoint `/sources/add/` that allows a new source to be pushed to a running instance of Mosaic.
+
+To do this you make a POST request with a JSON body composed of
+
+- a `name` property
+- a `definition` property
+
+### Example request body
+
+Pushing a new git repo source:
+
+```
+{
+    "name":"my-docs-preview",
+    "definition": {
+      "modulePath": "@jpmorganchase/mosaic-source-git-repo",
+      "namespace": "my-docs",
+      "options": {
+        "credentials":<access-token>,
+        "prefixDir": "my-docs",
+        "cache": true,
+        "subfolder": "docs",
+        "repo": <repo-url>,
+        "branch": "main",
+        "extensions": [".mdx"],
+        "remote": "origin"
+      }
+    }
+}
+```
+
+## Notes
+
+By default, these sources are marked as a "preview" which means `preview-` is appended to the source namespace and certain plugins will not be run on this source e.g. search and sitemap plugins.
+
+You can disabled this behavior in 2 ways:
+
+1. send the property `isPreview` with the value of false as part of the POST request body
+2. modify plugin definitions in the mosaic config file to set `previewDisabled` to be false for all plugins you wish have run on this source.

--- a/packages/cli/src/serve.ts
+++ b/packages/cli/src/serve.ts
@@ -80,6 +80,10 @@ export default async function serve(config, port, scope) {
     try {
       const { definition, name, isPreview = true } = req.body;
 
+      if (process.env.MOSAIC_ENABLE_SOURCE_PUSH !== 'true') {
+        throw new Error('Source push is disabled.');
+      }
+
       if (!definition) {
         throw new Error('Source definition is required');
       }

--- a/packages/cli/src/serve.ts
+++ b/packages/cli/src/serve.ts
@@ -73,4 +73,22 @@ export default async function serve(config, port, scope) {
       res.status(500).send(e.message).end();
     }
   });
+
+  app.post('/sources/add', async (req, res) => {
+    try {
+      const { definition } = req.body;
+      if (process.env.NODE_ENV === 'production') {
+        throw new Error('Sources cannot be added in production.');
+      }
+
+      if (!definition) {
+        throw new Error('Source definition is required');
+      }
+      const source = await mosaic.addSource(definition);
+      res.send(source !== undefined);
+    } catch (e) {
+      console.error(e);
+      res.status(500).send(e.message).end();
+    }
+  });
 }

--- a/packages/cli/src/serve.ts
+++ b/packages/cli/src/serve.ts
@@ -76,7 +76,8 @@ export default async function serve(config, port, scope) {
 
   app.post('/sources/add', async (req, res) => {
     try {
-      const { definition } = req.body;
+      const { definition, isPreview = true } = req.body;
+
       if (process.env.NODE_ENV === 'production') {
         throw new Error('Sources cannot be added in production.');
       }
@@ -84,8 +85,14 @@ export default async function serve(config, port, scope) {
       if (!definition) {
         throw new Error('Source definition is required');
       }
+
+      if (isPreview) {
+        const namespace = `preview-${definition.namespace}`;
+        definition.namespace = namespace;
+      }
+
       const source = await mosaic.addSource(definition);
-      res.send(source !== undefined);
+      res.send(source !== undefined ? definition.namespace : 'Unable to add source');
     } catch (e) {
       console.error(e);
       res.status(500).send(e.message).end();

--- a/packages/core/src/PullDocs.ts
+++ b/packages/core/src/PullDocs.ts
@@ -128,4 +128,8 @@ export default class PullDocs {
 
     return source;
   }
+
+  async stopSource(id: symbol) {
+    return this.#sourceManager.destroySource(id);
+  }
 }

--- a/packages/core/src/PullDocs.ts
+++ b/packages/core/src/PullDocs.ts
@@ -97,7 +97,7 @@ export default class PullDocs {
   }
 
   async start() {
-    return Promise.all(this.#sourceDefinitions.map(source => this.#addSource(source)));
+    return Promise.all(this.#sourceDefinitions.map(source => this.addSource(source)));
   }
 
   async stop() {
@@ -108,10 +108,12 @@ export default class PullDocs {
     return this.#sourceManager.triggerWorkflow(name, filePath, data);
   }
 
-  async #addSource(sourceDefinition) {
+  async addSource(sourceDefinition) {
     const source = await this.#sourceManager.addSource(sourceDefinition, {});
     source.onError(error => {
-      console.error(new Error(`Source '${source.id.description}' threw an exception. See below:`));
+      console.error(
+        new Error(`[Mosaic] Source '${source.id.description}' threw an exception. See below:`)
+      );
       console.error(error);
     });
     source.onExit(() => {

--- a/packages/core/src/Source.ts
+++ b/packages/core/src/Source.ts
@@ -128,7 +128,12 @@ export default class Source {
     plugins: PluginModuleDefinition[] = [],
     serialisers: SerialiserModuleDefinition[] = []
   ) {
-    this.#plugins.push(...plugins);
+    if (this.namespace.startsWith('preview-')) {
+      console.log('[Mosaic] Preview source detected, filtering plugins to use.');
+      this.#plugins.push(...plugins.filter(plugin => !plugin.previewDisabled));
+    } else {
+      this.#plugins.push(...plugins);
+    }
     this.#serialisers.push(...serialisers);
   }
 

--- a/packages/core/src/SourceManager.ts
+++ b/packages/core/src/SourceManager.ts
@@ -76,6 +76,11 @@ export default class SourceManager {
     this.#sources.forEach(source => source.stop());
   }
 
+  destroySource(id: symbol) {
+    const source = this.getSource(id);
+    source.stop();
+  }
+
   addSource(
     sourceDefinition: SourceModuleDefinition,
     options: Record<string, unknown>

--- a/packages/schemas/src/PluginModuleSchema.ts
+++ b/packages/schemas/src/PluginModuleSchema.ts
@@ -7,7 +7,7 @@ export const pluginModuleSchema = z.object({
    */
   modulePath: z.string({ required_error: 'A path to the plugin module is required.' }),
   /**
-   * Options to pass to the plugin lifecycle methods.
+   * Set to true to prevent the plugin from running
    */
   disabled: z.boolean().optional(),
   /**
@@ -21,7 +21,11 @@ export const pluginModuleSchema = z.object({
   /**
    * The importance of this plugin. This highest number plugin will be run first
    */
-  priority: z.number().optional()
+  priority: z.number().optional(),
+  /**
+   * Set to true to prevent the plugin from running when a source has a "preview" namespace
+   */
+  previewDisabled: z.boolean().optional()
 });
 
 export type PluginModuleDefinition = z.infer<typeof pluginModuleSchema>;

--- a/packages/site/.env.local
+++ b/packages/site/.env.local
@@ -3,3 +3,4 @@ MOSAIC_SNAPSHOT_DIR=snapshots/latest
 OPTIMIZE_IMAGES=false
 NEXTAUTH_URL=http://localhost:3000
 NODE_ENV=development
+MOSAIC_ENABLE_SOURCE_PUSH=true

--- a/packages/standard-generator/src/fs.config.js
+++ b/packages/standard-generator/src/fs.config.js
@@ -34,10 +34,12 @@ module.exports = {
   plugins: [
     {
       modulePath: '@jpmorganchase/mosaic-plugins/SiteMapPlugin',
+      previewDisabled: true,
       options: { siteUrl: process.env.SITE_URL || 'http://localhost:3000' }
     },
     {
       modulePath: '@jpmorganchase/mosaic-plugins/SearchIndexPlugin',
+      previewDisabled: true,
       options: { maxLineLength: 240, maxLineCount: 240 }
     },
     {


### PR DESCRIPTION
This allows you to push a source definition to an active mosaic instance.  Do we think it should add this definition to the mosaic config file as well?


## Questions/Issues

- At the moment, you could push a source definition and then if there is a restart the definition would be lost.
~~Also, disabled this in prod env.~~
- local folder definitions probably won't work, because the local folder needs to exist where mosaic is running

### Example

Post request to http://localhost:8080/sources/add

request body:

```
{
    "name":"davie-docs-preview",
    "definition": {
      "modulePath": "@jpmorganchase/mosaic-source-git-repo",
      "namespace": "davie",
      "options": {
        "credentials":<access-token> ,
        "prefixDir": "davie",
        "cache": true,
        "subfolder": "docs",
        "repo": "https://github.com/DavieReid/mosaic-docs.git",
        "branch": "main",
        "extensions": [".mdx"],
        "remote": "origin"
      }
    }
}
```