### PR TITLE
Improve generator

### DIFF
--- a/.changeset/famous-mirrors-type.md
+++ b/.changeset/famous-mirrors-type.md
@@ -1,0 +1,9 @@
+---
+'@jpmorganchase/mosaic-create-site': patch
+'@jpmorganchase/mosaic-standard-generator': patch
+---
+
+Mosaic site creators no longer needs to install `@jpmorganchase/mosaic-create-site` globally
+
+To generate a site, use `npx`
+`npx @jpmorganchase/mosaic-create-site create -o my-sample-site`

--- a/docs/quick-start/publish-site-to-aws.mdx
+++ b/docs/quick-start/publish-site-to-aws.mdx
@@ -10,8 +10,7 @@ Publish a site to AWS using S3 snapshots.
 ## Step 1: Generate a Mosaic site
 
 ```
-> yarn global add @jpmorganchase/mosaic-create-site
-> mosaic-create-site create -o my-sample-site
+> npx @jpmorganchase/mosaic-create-site -o my-sample-site
 > cd my-sample-site
 ```
 

--- a/docs/quick-start/site-generator.mdx
+++ b/docs/quick-start/site-generator.mdx
@@ -17,9 +17,7 @@ Use the Mosaic Site generator to generate a site and add an example source.
 The site generator expects to be run in a monorepo. If you are trying to set up a site in an empty directory, you will first need to run `yarn init` to create a `package.json` file.
 
 ```
-> yarn add @jpmorganchase/mosaic-create-site -W
-> yarn mosaic-create-site init
-> yarn mosaic-create-site create -o my-sample-site
+> npx @jpmorganchase/mosaic-create-site -o my-sample-site
 > cd my-sample-site
 ```
 

--- a/packages/create-site/README.md
+++ b/packages/create-site/README.md
@@ -57,7 +57,7 @@ Once you have created your `mosaic.generators.js`, we can think about configurin
 Running `create` will generate a Mosaic site from the configured templates.
 Lets see what this looks like by running the script with the `--interactive (-i)` and the `--output (-o)` flags.
 
-`npx @jpmorganchase/mosaic-create-site  --interactive --ouput <path to your output directory>`
+`npx @jpmorganchase/mosaic-create-site --interactive --ouput <path to your output directory>`
 
 You should see a menu appear giving you a list of the available Mosaic templates.
 

--- a/packages/create-site/README.md
+++ b/packages/create-site/README.md
@@ -2,13 +2,9 @@
 
 `@jpmorganchase/mosaic-create-site` is a CLI script which scaffolds your very own Mosaic site from pre-defined generators.
 
-## Installation
-
-`yarn add -g @jpmorganchase/mosaic-create-site`
-
 ## Basic Commands
 
-### `yarn mosaic-create-site init`
+### `npx @jpmorganchase/mosaic-create-site init`
 
 Running `init` will create a basic `mosaic.generators.js` in your current directory, this is an optional file, which enables
 you to add configurations to generators.
@@ -54,14 +50,14 @@ This particular config would create a package called `@jpmorganchase/mosaic-demo
     ]
 ```
 
-### `yarn mosaic-create-site create`
+### `npx @jpmorganchase/mosaic-create-site create`
 
 Once you have created your `mosaic.generators.js`, we can think about configuring your first Mosaic site.
 
 Running `create` will generate a Mosaic site from the configured templates.
 Lets see what this looks like by running the script with the `--interactive (-i)` and the `--output (-o)` flags.
 
-`yarn mosaic-create-site create --interactive --ouput <path to your output directory>`
+`npx @jpmorganchase/mosaic-create-site  --interactive --ouput <path to your output directory>`
 
 You should see a menu appear giving you a list of the available Mosaic templates.
 
@@ -264,7 +260,7 @@ Occasionally you might want to re-generate your site or switch templates.
 For this, you will need to pip the version of `@jpmorganchase/mosaic-create-site` to the latest version and re-run
 `create` with a `--force (-f)` flag to overwrite the existing site.
 
-`yarn mosaic create <-o path to your output directory> -g <generator name> -f`
+`npx @jpmorganchase/mosaic-create-site <-o path to your output directory> -g <generator name> -f`
 
 Aside from updating the standard config, the under-lying Mosaic dependencies for components, theme and layouts will also be updated.
 

--- a/packages/create-site/bin/mosaic-create-site.js
+++ b/packages/create-site/bin/mosaic-create-site.js
@@ -31,7 +31,7 @@ async function init({ silent = false } = {}) {
       '1. Edit your `mosaic.generators.js`, if you want to configure your site`s components, layouts or theme'
     );
     console.log(
-      '2. Run `yarn mosaic-create-site create -i` to generate your Mosaic site (use -f to overwrite existing files)'
+      '2. Run `npx @jpmorganchase/mosaic-create-site -i` to generate your Mosaic site (use -f to overwrite existing files)'
     );
   });
 }
@@ -43,6 +43,10 @@ async function readMosaicConfig(mosaicConfigPath) {
     await init({ silent: true });
   }
   try {
+    const nodeModulesPathRegexp = /(.*\/node_modules\/)/;
+    const nodeModulesPathMatches = __filename.match(nodeModulesPathRegexp);
+    process.env.NODE_PATH = `${process.env.NODE_PATH}${path.delimiter}${nodeModulesPathMatches[1]}`;
+    require('module').Module._initPaths();
     mosaicConfig = await require(normalizeRelativePath(
       mosaicConfigPath || defaultMosaicConfigPath
     ));

--- a/packages/standard-generator/src/generator.config.js
+++ b/packages/standard-generator/src/generator.config.js
@@ -74,6 +74,7 @@ module.exports = {
        */
       modulePath: '@jpmorganchase/mosaic-source-git-repo',
       namespace: 'mosaic', // each site has it's own namespace, think of this as your content's uid
+      disabled: !process.env.MOSAIC_DOCS_CLONE_CREDENTIALS, // use a boolean to enable/disable the source
       options: {
         // To run locally, enter your credentials to access the Git repo
         // e.g create the environment variable MOSAIC_DOCS_CLONE_CREDENTIALS


### PR DESCRIPTION
As a Mosaic Site creator we previously installed `@jpmorganchase/mosaic-create-site` globally and run

`yarn mosaic-create-site create -o my-sample-site`

We have switched the docs to use `npx` instead to avoid the need to globally install.

When running the create, we would read `mosaic.generators.js` which read the `@jpmorganchase/mosaic-standard-generator` using `require`. The problem was that for this to work, it needed a `package.json`. This worked OK, in monorepo situations where you have a `package.json` anyway but not for creating new projects from scratch.

By switching to `npx` we need to add the temporary path of `node-modules`, so that it can require in the standard generator without needing a local package.json. Owing to the way that require searches for references, this change will work for both monorepo and new project situations.