### PR TITLE
add dotenv-load to standard generator

### DIFF
--- a/packages/standard-generator/package.json
+++ b/packages/standard-generator/package.json
@@ -20,5 +20,7 @@
     "dist",
     "src"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "dotenv-load": "^2.0.1"
+  }
 }


### PR DESCRIPTION
I'm trying to follow/amend the getting started instructions and it's failing because this package is missing from the standard generator dependencies.