### PR TITLE
With session update

### DIFF
--- a/.changeset/lazy-clocks-lay.md
+++ b/.changeset/lazy-clocks-lay.md
@@ -1,0 +1,7 @@
+---
+'@jpmorganchase/mosaic-site-middleware': patch
+---
+
+fix: remove env variable check in `withSession` middleware
+
+The `NEXTAUTH_SECRET` env variable is not always required. It is possible to pass the secret as an option to `next-auth`

--- a/packages/site-middleware/src/withSession.ts
+++ b/packages/site-middleware/src/withSession.ts
@@ -35,12 +35,6 @@ export const withSession: MosaicMiddleware<SessionProps<unknown>, SessionOptions
   if (process.env.NEXT_PUBLIC_ENABLE_LOGIN !== 'true') {
     return {};
   }
-  if (!process.env.NEXTAUTH_SECRET) {
-    const errorMessage = '`process.env.NEXTAUTH_SECRET` must be set in environment variables.';
-    throw new MiddlewareError(500, context.resolvedUrl, [errorMessage], {
-      show500: true
-    });
-  }
 
   if (!options?.authOptions) {
     const errorMessage = '`authOptions` must be provided.';


### PR DESCRIPTION
The `NEXTAUTH_SECRET` env variable is not always required. It is possible to pass the secret as an option to `next-auth`