### PR TITLE
Fix props table plugin component path

### DIFF
--- a/.changeset/wicked-horses-carry.md
+++ b/.changeset/wicked-horses-carry.md
@@ -1,0 +1,5 @@
+---
+'@jpmorganchase/mosaic-plugins': minor
+---
+
+Add path resolve in order for component path to be correct regardless of the plugin location

--- a/packages/plugins/src/PropsTablePlugin.ts
+++ b/packages/plugins/src/PropsTablePlugin.ts
@@ -5,6 +5,7 @@ import { remark } from 'remark';
 import { visit } from 'unist-util-visit';
 import { parse } from 'react-docgen-typescript';
 import type { Node } from 'unist';
+import path from 'path';
 
 const options = {
   propFilter: prop => !/@types[\\/]react[\\/]/.test(prop.parent?.fileName || '')
@@ -34,7 +35,9 @@ const PropsTablePlugin: PluginType<PropsTablePluginPage> = {
         (node: LeafNode) => {
           if (node.name !== 'propsTable') return;
 
-          const propsTableData = parse(node.attributes.src, options)[0].props;
+          const componentPath = path.resolve(node.attributes.src);
+
+          const propsTableData = parse(componentPath, options)[0].props;
 
           const tableHeaders = {
             type: 'tableRow',


### PR DESCRIPTION
Fix issue where component path is not resolved correctly (this was only noticeable when testing the plugin on the Salt site). I've tested on the site via a patch https://github.com/jpmorganchase/salt-ds/pull/1718. 