### PR TITLE
Merge colocated json files

### DIFF
--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -221,16 +221,15 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
 
       function sortPagesByPriority(sidebarData) {
         const pagesByPriority = sidebarData.map(page => {
-          if (page.childNodes.length > 1) {
+          if (page.childNodes?.length > 1) {
             const pagesByPriority = page.childNodes.sort(
               (pageA, pageB) =>
                 (pageB.priority ? pageB.priority : -1) - (pageA.priority ? pageA.priority : -1)
             );
             sortPagesByPriority(page.childNodes);
             return { ...page, childNodes: pagesByPriority };
-          } else {
-            return page;
           }
+          return page;
         });
         return pagesByPriority;
       }


### PR DESCRIPTION
If two sources attempt to write files to the same dir, they'll each create a sidebar.json. This change catches those duplicates and merges them.

For example if SOURCE_ONE adds `developer/newsletters/index.mdx` and SOURCE_TWO adds `developer/newsletters/fascinating-newslertter.mdx`, both should be included in a single developer/newsletters/sidebar.json`