### PR TITLE
fix: ensure main content area uses all available height

### DIFF
--- a/packages/layouts/src/LayoutBase/styles.css.ts
+++ b/packages/layouts/src/LayoutBase/styles.css.ts
@@ -43,7 +43,8 @@ export default {
     gridArea: 'base-layout-main',
     display: 'flex',
     justifyContent: 'center',
-    zIndex: 1
+    zIndex: 1,
+    minHeight: `calc(100vh - ${config.appHeader.height}px)`
   }),
 
   header: style([

--- a/packages/site-components/src/VerticalNavigation.tsx
+++ b/packages/site-components/src/VerticalNavigation.tsx
@@ -49,7 +49,7 @@ const createMenuItemStyles = colorMode => ({
       color: active
         ? colorMode === 'light'
           ? 'var(--mosaic-color-light-navigable-selectableLink-selectedLabel)'
-          : 'var(--mosaic-color-light-navigable-selectableLink-selectedLabel)'
+          : 'var(--mosaic-color-dark-navigable-selectableLink-selectedLabel)'
         : colorMode === 'light'
         ? 'var(--mosaic-color-light-navigable-selectableLink-unselectedLabel)'
         : 'var(--mosaic-color-dark-navigable-selectableLink-unselectedLabel)'


### PR DESCRIPTION
When there is not enough content to fill the page, dark mode looks awful as half the page is white.


See here --> https://mosaic-mosaic-dev-team.vercel.app/mosaic/author/index

Also fixes the label color of the active sidebar item when in dark mode.
