### PR TITLE
Hide sidebar scrollbar when not needed

### DIFF
--- a/packages/theme/src/sidebar/sidebar.css.ts
+++ b/packages/theme/src/sidebar/sidebar.css.ts
@@ -18,7 +18,7 @@ export const sidebar = styleVariants({
   ],
   scrollable: {
     display: 'flex',
-    overflowY: 'scroll',
+    overflowY: 'auto',
     top: `${config.appHeader.height}px`
   }
 });


### PR DESCRIPTION
Sidebar will always show a scrollbar on the side, especially ugly on Windows
e.g. https://mosaic-mosaic-dev-team.vercel.app/mosaic/getting-started/index

This PR hides it when not needed