### PR TITLE
Change case of TOC text

### DIFF
--- a/packages/site-components/src/TableOfContents/TableOfContents.tsx
+++ b/packages/site-components/src/TableOfContents/TableOfContents.tsx
@@ -95,8 +95,8 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({ items }) => {
 
   return items.length ? (
     <nav>
-      <Caption1>On this Page</Caption1>
-      <ul aria-label="Table of Contents" className={styles.list} role="tree">
+      <Caption1>On this page</Caption1>
+      <ul aria-label="Table of contents" className={styles.list} role="tree">
         {items.map((item, i) => (
           <TableOfContentsItem
             current={selectedHeading}


### PR DESCRIPTION
A content review of some Salt website pages flagged the capitalization of the "On this Page" heading above the TOC links. As per our writing style guide (available on the JPM-internal UI Toolkit site), we use sentence case for page titles and headings, so it should read: "On this page" (note the lowercase 'p').

This PR fixes that and also corrects the capitalization on the `aria-label` on the `<ul>` too.