### PR TITLE
fix: prevent `SidebarPlugin` from breaking when there is no index file

### DIFF
--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -248,7 +248,17 @@ const SidebarPlugin: PluginType<SidebarPluginPage, SidebarPluginOptions, Sidebar
           let pages = await createPageList(rootDir);
           pages = pages.filter(page => removeExcludedPages(page));
           const groupMap = createGroupMap(pages);
+
           const sidebarData = linkGroupMap(groupMap, rootDir);
+          if (sidebarData[0] === undefined) {
+            console.warn(
+              `[Mosaic] SidebarPlugin - Unable to create a Sidebar grouping for ${rootDir}`
+            );
+            console.log(
+              '[Mosaic] SidebarPlugin - likely you have a directory without an index file'
+            );
+            return;
+          }
           const pagesByPriority = sortPagesByPriority(sidebarData);
           addNavigationToFrontmatter(pagesByPriority);
           const pagesWithRootMovedDown = moveRootPageDown(pagesByPriority);


### PR DESCRIPTION
When a directory does not include and index file, the group linking in the sidebar plugin breaks because for a "group" to be identified we check for the existence of an index page.

This PR simply logs a warning and provides an indication of what directory has the problem.  Ideally we should define and upgrade the logic so that group linking can happen without the need for index pages.

To sort the sidebar you just need to add an index page.