### PR TITLE
fix: reintroduce support for tab `label`

### DIFF
--- a/packages/components/src/TabsBase/TabsButton.tsx
+++ b/packages/components/src/TabsBase/TabsButton.tsx
@@ -4,6 +4,10 @@ import { TabMenuItemType } from './index';
 import styles from './styles.css';
 
 export interface TabsButtonItem {
+  /**
+   * @deprecated use title
+   * Label of Tab */
+  label?: string;
   /** Callback when Tab is selected */
   onSelect: (event, string) => void;
   /** Title of Tab */
@@ -21,6 +25,6 @@ export const TabsButton: FC<React.PropsWithChildren<TabButtonProps>> = ({ item }
     onClick={event => item.onSelect(event, item.title)}
     role="button"
   >
-    {item.title}
+    {item.title || item.label}
   </div>
 );

--- a/packages/components/src/TabsBase/TabsLink.tsx
+++ b/packages/components/src/TabsBase/TabsLink.tsx
@@ -5,6 +5,10 @@ import { TabMenuItemType } from './index';
 import styles from './styles.css';
 
 export interface TabsLinkItem {
+  /**
+   * @deprecated use title
+   * Label of Tab */
+  label?: string;
   /** URL linked by Tab */
   link: string;
   /** Title of Tab */
@@ -20,7 +24,7 @@ export interface TabsLinkProps {
 
 export const TabsLink: FC<React.PropsWithChildren<TabsLinkProps>> = ({ children, item }) => (
   <Link className={styles.menuLink} link={item.link} variant="selectable">
-    {item.title}
+    {item.title || item.label}
     {children}
   </Link>
 );

--- a/packages/components/src/TabsBase/TabsMenuButton.tsx
+++ b/packages/components/src/TabsBase/TabsMenuButton.tsx
@@ -7,6 +7,10 @@ import { TabsLinkItem } from './TabsLink';
 import { TabMenuItemType } from './index';
 
 export interface TabsMenuButtonItem {
+  /**
+   * @deprecated use title
+   * Label of Tab */
+  label?: string;
   /** Collection of link options */
   links: TabsLinkItem[];
   /** Callback when Tab is selected */
@@ -31,7 +35,7 @@ export const TabsMenuButton: FC<TabsMenuButtonProps> = ({ children, className, i
       onItemClick: (sourceItem, event) => item.onSelect(event, sourceItem)
     }}
   >
-    <span>{item.title}</span>
+    <span>{item.title || item.label}</span>
     {children}
   </MenuButton>
 );


### PR DESCRIPTION
Salt switched from `label` to `title` for Tabs but we can support both to prevent the need for content changes.