### PR TITLE
feat: add `LinkButton` to mosaic markdown components

### DIFF
--- a/.changeset/light-cherries-retire.md
+++ b/.changeset/light-cherries-retire.md
@@ -1,0 +1,6 @@
+---
+'@jpmorganchase/mosaic-components': patch
+'@jpmorganchase/mosaic-site': patch
+---
+
+`LinkButton` added to default MDX components.

--- a/packages/components/src/LinkButton.css.ts
+++ b/packages/components/src/LinkButton.css.ts
@@ -6,6 +6,7 @@ export default {
     {
       display: 'inline-flex',
       alignItems: 'center',
+      justifyContent: 'center',
       letterSpacing: '0.6px',
       fontWeight: vars.fontWeight.bold,
       fontSize: vars.fontSize.s50,

--- a/packages/components/src/Markdown/index.tsx
+++ b/packages/components/src/Markdown/index.tsx
@@ -97,6 +97,7 @@ import { withStyledTypography } from '../Typography/withStyledTypography';
 import { withMarkdownSpacing } from './withMarkdownSpacing';
 import { ListItem, OrderedList, UnorderedList } from '../List';
 import type { ListItemProps, OrderedListProps, UnOrderedListProps } from '../List';
+import { LinkButton, LinkButtonProps } from '../LinkButton';
 
 export { getMarkdownElements } from './markdownElements';
 
@@ -142,6 +143,7 @@ export const getMarkdownComponents = () => ({
   Label: withMarkdownSpacing<LabelProps>(Label),
   Link,
   LinkBase: withMarkdownSpacing<LinkBaseProps>(LinkBase),
+  LinkButton: withMarkdownSpacing<LinkButtonProps>(LinkButton),
   LinkText: withMarkdownSpacing<LinkTextProps>(LinkText),
   Links: withMarkdownSpacing<LinksProps>(Links),
   ListItem: withMarkdownSpacing<ListItemProps>(ListItem),


### PR DESCRIPTION
Allow folks to use `LinkButton` in there docs.  Salt `Button` no longer supports `href` so a link button can be used instead.