### PR TITLE
Shared config updates

### DIFF
--- a/packages/core/src/Source.ts
+++ b/packages/core/src/Source.ts
@@ -113,7 +113,8 @@ export default class Source {
         pageExtensions: this.#pageExtensions,
         ignorePages: this.#ignorePages,
         serialiser: this.serialiser,
-        config: this.config.asReadOnly()
+        config: this.config.asReadOnly(),
+        namespace: this.namespace
       }
     );
     const timeTaken = new Date().getTime() - initTime;
@@ -149,7 +150,8 @@ export default class Source {
       pageExtensions: this.#pageExtensions,
       ignorePages: this.#ignorePages,
       serialiser: this.serialiser,
-      config: this.config.asReadOnly()
+      config: this.config.asReadOnly(),
+      namespace: this.namespace
     });
     const timeTaken = new Date().getTime() - initTime;
     if (timeTaken > 800) {

--- a/packages/core/src/worker/Source.worker.ts
+++ b/packages/core/src/worker/Source.worker.ts
@@ -39,7 +39,8 @@ if (isMainThread) {
           config,
           serialiser,
           ignorePages: workerData.ignorePages,
-          pageExtensions: workerData.pageExtensions
+          pageExtensions: workerData.pageExtensions,
+          namespace: workerData.namespace
         })
       ),
       switchMap((pages: Page[]) =>
@@ -58,7 +59,8 @@ if (isMainThread) {
           config,
           ignorePages: workerData.ignorePages,
           pageExtensions: workerData.pageExtensions,
-          serialiser
+          serialiser,
+          namespace: workerData.namespace
         });
         // In the main thread we would freeze the filesystem here, but since we throw it away after sending it to the parent process,
         // we don't bother freezing

--- a/packages/plugins/src/SharedConfigPlugin.ts
+++ b/packages/plugins/src/SharedConfigPlugin.ts
@@ -58,7 +58,7 @@ const SharedConfigPlugin: PluginType<SharedConfigPluginPage, SharedConfigPluginO
     if (indexPagesWithSharedConfig.length === 0 && indexPages.length > 0) {
       const rootPath = indexPages[0].fullPath;
       const applyNamespaceSharedConfig = {
-        [`${namespace}-${rootPath}`]: {
+        [`${namespace}~~${rootPath}`]: {
           paths: indexPages.map(indexPage => indexPage.fullPath),
           rootPath,
           namespace
@@ -153,7 +153,7 @@ const SharedConfigPlugin: PluginType<SharedConfigPluginPage, SharedConfigPluginO
     const { applyNamespaceSharedConfig } = globalConfig.data;
 
     if (applyNamespaceSharedConfig === undefined) {
-      // there is no source that exists that has told us it needs to share a parent shared config
+      // there is no source that exists that has told us it needs to share a namespace shared-config
       return;
     }
 
@@ -164,7 +164,7 @@ const SharedConfigPlugin: PluginType<SharedConfigPluginPage, SharedConfigPluginO
       namespace: string;
     }[] = Object.keys(applyNamespaceSharedConfig)
       .filter(key => {
-        const keyNamespace = key.split('-')?.[0];
+        const keyNamespace = key.split('~~')?.[0];
         return keyNamespace === namespace;
       })
       .map(key => applyNamespaceSharedConfig?.[key] || []);
@@ -182,7 +182,6 @@ const SharedConfigPlugin: PluginType<SharedConfigPluginPage, SharedConfigPluginO
             recursive: true
           });
         }
-
         let parentDir = path.posix.join(path.posix.dirname(String(applyPath)), '../');
         let closestSharedConfigPath = path.posix.join(parentDir, options.filename);
 

--- a/packages/types/src/Plugin.ts
+++ b/packages/types/src/Plugin.ts
@@ -30,6 +30,7 @@ export type Plugin<
    * @param pages Array of pages from the source
    * @param param.serialiser A matching `Serialiser` for serialising/deserialising pages when reading/writing to the filesystem
    * @param param.config A mutable object for sharing data with other lifecycle phases of all plugins for this source (including in the main thread) in this plugin
+   * @param param.namespace The namespace of the source running the plugin
    * @param options The options passed in when declaring the plugin
    * @returns {Promise<Page[]>} Must re-return an array of `Page` objects, modified or not
    */
@@ -40,6 +41,7 @@ export type Plugin<
       config: MutableData<ConfigData>;
       pageExtensions: string[];
       ignorePages: string[];
+      namespace: string;
     },
     options?: TOptions
   ) => Promise<Array<TPage>>;
@@ -49,6 +51,7 @@ export type Plugin<
    * @param mutableFilesystem Mutable virtual filesystem instance with all of this source's pages inside (and symlinks applied)
    * @param param.serialiser A matching `Serialiser` for serialising/deserialising pages when reading/writing to the filesystem
    * @param param.config A mutable object for sharing data with other lifecycle phases of all plugins for this source (including in the main thread) in this plugin
+   * @param param.namespace The namespace of the source running the plugin
    * @param options The options passed in when declaring the plugin
    * @returns {void} No return expected
    */
@@ -59,6 +62,7 @@ export type Plugin<
       pageExtensions: string[];
       ignorePages: string[];
       config: MutableData<ConfigData>;
+      namespace: string;
     },
     options?: TOptions
   ) => Promise<void>;
@@ -76,6 +80,7 @@ export type Plugin<
    * @param param.globalConfig An immutable object for reading data from other lifecycle phases of all plugins. Shared across all sources.
    * @param param.sharedFilesystem Mutable filesystem instance independent of any sources. Useful for global pages, like sitemaps
    * @param param.globalFilesystem Immutable union filesystem instance with all source's pages (and symlinks applied)
+   * @param param.namespace The namespace of the source running the plugin
    * @param options The options passed in when declaring the plugin
    * @returns {void} No return expected
    */
@@ -89,6 +94,7 @@ export type Plugin<
       globalConfig: ImmutableData<GlobalConfigData>;
       pageExtensions: string[];
       ignorePages: string[];
+      namespace: string;
     },
     options?: TOptions
   ) => Promise<void>;
@@ -101,6 +107,7 @@ export type Plugin<
    * @param param.config An immutable object for reading data from other lifecycle phases of all plugins for this source in the child process for this plugin
    * @param param.serialiser A matching `Serialiser` for serialising/deserialising pages when reading/writing to the filesystem
    * @param param.globalFilesystem Immutable union filesystem instance with all source's pages (and symlinks applied)
+   * @param param.namespace The namespace of the source running the plugin
    * @param options The options passed in when declaring the plugin
    * @returns {Promise<boolean>} A boolean indicating whether to clear the cache for this source
    */
@@ -112,6 +119,7 @@ export type Plugin<
       globalFilesystem: IUnionVolume;
       pageExtensions: string[];
       ignorePages: string[];
+      namespace: string;
     },
     options?: TOptions
   ) => Promise<boolean>;


### PR DESCRIPTION
It is possible to have a source that is considered a "child" of another source.  Consider:

- Source A contains a lot of product docs and defines a shared config for the products site (parent source)
- Source B contains docs for a single product and does not have any shared config. (child source)

To a Mosaic site, the product of Source B should work the same as all the other products from Source A.  This includes using the shared config of Source A in pages that come from Source B.

This change adds the above feature by allowing a source to apply it's shared config to another source **if they share the same namespace**

## Timeline
- Source A loads it pages and the shared config plugin creates the shared-config
- Source B loads its pages and writes to the global config explaining that it doesn't have any shared config and that it has namespace "whatever"
- The afterUpdate plugin lifecycle triggers for all sources 
- Source A detects that it has the same namespace as Source B
- For each index page in Source B, Source A works out what the closest shared config file should be
- Source A then creates a file in the shared filesystem so that Source B now has a shared config


