### PR TITLE
Breadcrumbs fixes

### DIFF
--- a/.changeset/rare-elephants-wave.md
+++ b/.changeset/rare-elephants-wave.md
@@ -1,0 +1,12 @@
+---
+'@jpmorganchase/mosaic-site': patch
+'@jpmorganchase/mosaic-site-components': patch
+'@jpmorganchase/mosaic-standard-generator': patch
+---
+
+### Fixes
+
+- Breadcrumb label matches sidebar label if available.
+- When breadcrumbs collapse into a menu button, the breadcrumb label is used for the menu items.
+- Collapsed breadcrumbs will navigate to the page the breadcrumb represents
+- Breadcrumb links no longer include the unnecessary file extension

--- a/packages/plugins/src/BreadcrumbsPlugin.ts
+++ b/packages/plugins/src/BreadcrumbsPlugin.ts
@@ -1,11 +1,11 @@
 import path from 'path';
-import type { Page, Plugin as PluginType } from '@jpmorganchase/mosaic-types';
-import { breadcrumbsLayoutSchema } from '@jpmorganchase/mosaic-schemas';
+import type { Plugin as PluginType } from '@jpmorganchase/mosaic-types';
 import PluginError from './utils/PluginError.js';
+import { SidebarPluginPage } from './SidebarPlugin.js';
 
 export type Breadcrumb = { label: string; path: string; id: string };
 
-export interface BreadcrumbsPluginPage extends Page {
+export interface BreadcrumbsPluginPage extends SidebarPluginPage {
   breadcrumbs?: Array<Breadcrumb>;
   layout?: string;
 }
@@ -21,33 +21,31 @@ const BreadcrumbsPlugin: PluginType<BreadcrumbsPluginPage, BreadcrumbsPluginOpti
   async $afterSource(pages, _, options) {
     for (const page of pages) {
       try {
-        if (breadcrumbsLayoutSchema.safeParse(page?.layout).success) {
-          const breadcrumbs: Array<Breadcrumb> = [];
-          let currentPage = page;
-          let parentDir = path.posix.normalize(path.posix.dirname(currentPage.fullPath));
-          const maxBreadcrumbCount = page.fullPath.split('/').length;
+        const breadcrumbs: Array<Breadcrumb> = [];
+        let currentPage = page;
+        let parentDir = path.posix.normalize(path.posix.dirname(currentPage.fullPath));
+        const maxBreadcrumbCount = page.fullPath.split('/').length;
 
-          while (currentPage !== undefined && breadcrumbs.length < maxBreadcrumbCount) {
-            breadcrumbs.unshift({
-              label: currentPage.title,
-              path: currentPage.route,
-              id: currentPage.fullPath
-            });
+        while (currentPage !== undefined && breadcrumbs.length < maxBreadcrumbCount) {
+          breadcrumbs.unshift({
+            label: currentPage.sidebar?.label || currentPage.title,
+            path: currentPage.route,
+            id: currentPage.fullPath
+          });
 
-            currentPage = pages.find(
-              // eslint-disable-next-line @typescript-eslint/no-loop-func
-              item => item.fullPath === path.posix.join(parentDir, options.indexPageName)
-            );
-            if (currentPage) {
-              parentDir = path.posix.dirname(path.posix.join(String(currentPage.fullPath), '..'));
-            }
+          currentPage = pages.find(
+            // eslint-disable-next-line @typescript-eslint/no-loop-func
+            item => item.fullPath === path.posix.join(parentDir, options.indexPageName)
+          );
+          if (currentPage) {
+            parentDir = path.posix.dirname(path.posix.join(String(currentPage.fullPath), '..'));
           }
+        }
 
-          if (!page.breadcrumbs) {
-            // filter out any duplicate breadcrumbs
-            const map = new Map(breadcrumbs.map(crumb => [crumb.id, crumb]));
-            page.breadcrumbs = [...map.values()];
-          }
+        if (!page.breadcrumbs) {
+          // filter out any duplicate breadcrumbs
+          const map = new Map(breadcrumbs.map(crumb => [crumb.id, crumb]));
+          page.breadcrumbs = [...map.values()];
         }
       } catch (e) {
         throw new PluginError(e.message, page.fullPath);

--- a/packages/plugins/src/SidebarPlugin.ts
+++ b/packages/plugins/src/SidebarPlugin.ts
@@ -27,7 +27,7 @@ interface SidebarPluginConfigData {
   refs: { [key: string]: { $$path: (number | string)[]; $$value: string }[] };
 }
 
-interface SidebarPluginPage extends Page {
+export interface SidebarPluginPage extends Page {
   sidebar?: {
     label?: string;
   };

--- a/packages/plugins/src/__tests__/BreadcrumbsPlugin.test.ts
+++ b/packages/plugins/src/__tests__/BreadcrumbsPlugin.test.ts
@@ -106,32 +106,5 @@ describe('GIVEN the BreadcrumbsPlugin', () => {
         });
       });
     });
-
-    describe('AND WHEN a page has a layout without breadcrumbs UI', () => {
-      beforeEach(async () => {
-        const pagesWithWrongLayout = [
-          {
-            fullPath: '/FolderA/index.mdx',
-            route: 'route/folderA/index',
-            title: 'Folder A Index',
-            layout: 'Landing'
-          },
-          {
-            fullPath: '/FolderA/pageA.mdx',
-            route: 'route/folderA/pageA',
-            title: 'Folder A Page A',
-            layout: 'Newsletter'
-          }
-        ];
-        const $afterSource = BreadcrumbsPlugin.$afterSource;
-        // @ts-ignore
-        updatedPages =
-          (await $afterSource?.(pagesWithWrongLayout, {}, { indexPageName: 'index.mdx' })) || [];
-      });
-      test('THEN **NO** breadcrumbs are added to the page', () => {
-        const breadcrumbs = (updatedPages && updatedPages[0].breadcrumbs) || [];
-        expect(breadcrumbs.length).toEqual(0);
-      });
-    });
   });
 });

--- a/packages/site-components/src/Breadcrumbs/Breadcrumb.tsx
+++ b/packages/site-components/src/Breadcrumbs/Breadcrumb.tsx
@@ -1,6 +1,8 @@
 import React, { forwardRef, ReactNode } from 'react';
 import { Link } from '@jpmorganchase/mosaic-components';
 
+import styles from './styles.css';
+
 export interface BreadcrumbProps {
   children?: ReactNode;
   href?: string;
@@ -13,11 +15,15 @@ export const Breadcrumb = forwardRef<HTMLLinkElement, BreadcrumbProps>(function 
   { children, isCurrentLevel, ...props },
   ref
 ) {
-  return isCurrentLevel ? (
-    <span>{children}</span>
-  ) : (
-    <Link endIcon="none" ref={ref} variant="regular" {...props}>
-      {children}
-    </Link>
+  return (
+    <li className={styles.wrapper}>
+      {isCurrentLevel ? (
+        <span>{children}</span>
+      ) : (
+        <Link endIcon="none" ref={ref} variant="regular" {...props}>
+          {children}
+        </Link>
+      )}
+    </li>
   );
 });

--- a/packages/site-components/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/site-components/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useRouter } from 'next/router';
 import { Breadcrumbs as SaltBreadcrumbs } from '@salt-ds/lab';
 import { Breadcrumb } from './Breadcrumb';
 
@@ -16,19 +17,41 @@ export type BreadcrumbsProps = {
 };
 
 export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ breadcrumbs, enabled }) => {
+  const router = useRouter();
   if (!enabled) {
     return null;
   }
+
+  /**
+   * TODO - we need appropriate keyboard nav support as well
+   * The slat cascading menu keyboard nav does not seem to work
+   * so not much point adding support for enter key selection here
+   */
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLDivElement;
+    if (target.classList.contains('saltMenuItem-menuItemText')) {
+      const breadcrumbIndex = breadcrumbs.findIndex(
+        breadcrumb => breadcrumb.label.toLowerCase() === target.textContent?.toLowerCase()
+      );
+
+      if (breadcrumbIndex > -1) {
+        router.push(breadcrumbs[breadcrumbIndex].path);
+      }
+    }
+  };
+
   return (
-    <SaltBreadcrumbs className={styles.root} itemsBeforeCollapse={2} maxItems={5}>
-      {breadcrumbs.map(
-        value =>
-          value && (
-            <Breadcrumb href={value.path} key={`${value.id}`} overflowLabel={value.label}>
-              {value.label}
-            </Breadcrumb>
-          )
-      )}
-    </SaltBreadcrumbs>
+    <div onClick={handleClick}>
+      <SaltBreadcrumbs className={styles.root} itemsBeforeCollapse={2} maxItems={5}>
+        {breadcrumbs.map(
+          value =>
+            value && (
+              <Breadcrumb href={value.path} key={`${value.id}`} overflowLabel={value.label}>
+                {value.label}
+              </Breadcrumb>
+            )
+        )}
+      </SaltBreadcrumbs>
+    </div>
   );
 };

--- a/packages/site-components/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/site-components/src/Breadcrumbs/Breadcrumbs.tsx
@@ -19,15 +19,14 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ breadcrumbs, enabled }
   if (!enabled) {
     return null;
   }
-
   return (
     <SaltBreadcrumbs className={styles.root} itemsBeforeCollapse={2} maxItems={5}>
       {breadcrumbs.map(
-        (value, index) =>
+        value =>
           value && (
-            <li className={styles.wrapper} key={`${value.id}-${index}`}>
-              <Breadcrumb href={value.path}>{value.label}</Breadcrumb>
-            </li>
+            <Breadcrumb href={value.path} key={`${value.id}`} overflowLabel={value.label}>
+              {value.label}
+            </Breadcrumb>
           )
       )}
     </SaltBreadcrumbs>

--- a/packages/standard-generator/src/fs.config.js
+++ b/packages/standard-generator/src/fs.config.js
@@ -62,7 +62,8 @@ module.exports = {
     // TODO: Remove this plugin once the docs add file extensions in refs
     {
       modulePath: '@jpmorganchase/mosaic-plugins/PagesWithoutFileExtPlugin',
-      options: {}
+      options: {},
+      priority: 1
     },
     {
       modulePath: '@jpmorganchase/mosaic-plugins/SidebarPlugin',


### PR DESCRIPTION
There were a few issues with breadcrumbs that have now been resolved

1. We would only ever see 3 breadcrumbs because we were checking that the page layout supports breadcrumbs.  Removed this as it causes more harm than good
2. Breadcrumb label did not match what was in the sidebar.
3. When breadcrumbs collapse into a menu button, the label was not displayed.
4. Collapsed breadcrumbs were only labels and would not navigate anywhere
5. Breadcrumb links had the file extension in the route.  Sorted by running the `PagesWithoutFileExtPlugin` with a higher priority by default.

All of the above are resolved.