### PR TITLE
feat: provide ability to set page default layout on LayoutProvider

### DIFF
--- a/.changeset/smooth-tables-build.md
+++ b/.changeset/smooth-tables-build.md
@@ -1,0 +1,14 @@
+---
+'@jpmorganchase/mosaic-layouts': patch
+'@jpmorganchase/mosaic-site': patch
+---
+
+## Feature
+
+Provide the ability to set the default page layout at the root of a Mosaic site. Pages without a layout in their metadata will use this layout.
+
+```
+<LayoutProvider layoutComponents={layoutComponents} defaultLayout='DetailTechnical'>
+    <Page/>
+</LayoutProvider>
+```

--- a/packages/layouts/src/LayoutProvider.tsx
+++ b/packages/layouts/src/LayoutProvider.tsx
@@ -1,9 +1,9 @@
 import React, { FC, ReactNode } from 'react';
 import { useLayout } from '@jpmorganchase/mosaic-store';
 import { usePageState } from '@jpmorganchase/mosaic-content-editor-plugin';
-import { FullWidth } from './layouts/FullWidth';
 
 import type { LayoutProps } from './types';
+import * as layouts from './layouts';
 
 export type LayoutProviderProps = {
   layoutComponents?: {
@@ -11,21 +11,23 @@ export type LayoutProviderProps = {
   };
   LayoutProps?: LayoutProps;
   children: ReactNode;
+  defaultLayout?: string;
 };
 
 export const LayoutProvider: FC<LayoutProviderProps> = ({
   children,
   layoutComponents,
-  LayoutProps = {}
+  LayoutProps = {},
+  defaultLayout = 'FullWidth'
 }) => {
-  const { layout: layoutInStore = 'FullWidth' } = useLayout();
+  const { layout: layoutInStore = defaultLayout } = useLayout();
   const { pageState } = usePageState();
   const layout = pageState !== 'VIEW' ? 'EditLayout' : layoutInStore;
 
   let LayoutComponent: FC<LayoutProps> | undefined = layoutComponents?.[layout] as FC<LayoutProps>;
   if (!LayoutComponent) {
-    console.error(`Layout ${layout} is not supported, defaulting to FullWidth`);
-    LayoutComponent = FullWidth;
+    console.error(`Layout ${layout} is not supported, defaulting to ${defaultLayout}`);
+    LayoutComponent = layouts[defaultLayout];
   }
   return LayoutComponent ? (
     <LayoutComponent {...LayoutProps}>{children}</LayoutComponent>


### PR DESCRIPTION
Provide the ability to set the default page layout at the root of a Mosaic site. Pages without `layout` in their metadata will use this layout.