### PR TITLE
Fix edition filter view

### DIFF
--- a/.changeset/late-kings-sit.md
+++ b/.changeset/late-kings-sit.md
@@ -1,0 +1,8 @@
+---
+'@jpmorganchase/mosaic-components': patch
+'@jpmorganchase/mosaic-site': patch
+---
+
+## Fixes
+
+Prevent `EditionFilterView` from showing `Rendered fewer hooks than expected` error when a filter is appled.

--- a/packages/components/src/EditionFilterView/index.tsx
+++ b/packages/components/src/EditionFilterView/index.tsx
@@ -4,7 +4,6 @@ import classnames from 'clsx';
 import { FilterResultCount, FilterView } from '../FilterView';
 import { FilterDropdown, FilterSortDropdown } from '../FilterToolbar';
 import { EditionTileLink } from '../EditionTileLink';
-import { useBreakpoint } from '../useBreakpoint';
 import { FormattedContent } from '../FormattedContent';
 import styles from './styles.css';
 
@@ -59,24 +58,20 @@ export type EditionFilterViewProps = {
   ItemRenderer: EditionFilterViewRenderer;
 };
 
-export const DefaultEditionFilterViewRenderer: EditionFilterViewRenderer = (item, itemIndex) => {
-  const breakpoint = useBreakpoint();
-  return (
-    <EditionTileLink
-      description={
-        item.formattedDescription ? (
-          <FormattedContent>{item.formattedDescription}</FormattedContent>
-        ) : null
-      }
-      eyebrow={item.eyebrow}
-      image={item.image}
-      imagePlacement={breakpoint === 'mobile' ? 'fullWidth' : 'left'}
-      key={`editionTile-${itemIndex}`}
-      link={item.link}
-      title={item.title}
-    />
-  );
-};
+export const DefaultEditionFilterViewRenderer: EditionFilterViewRenderer = (item, itemIndex) => (
+  <EditionTileLink
+    description={
+      item.formattedDescription ? (
+        <FormattedContent>{item.formattedDescription}</FormattedContent>
+      ) : null
+    }
+    eyebrow={item.eyebrow}
+    image={item.image}
+    key={`editionTile-${itemIndex}`}
+    link={item.link}
+    title={item.title}
+  />
+);
 export const EditionFilterView: React.FC<React.PropsWithChildren<EditionFilterViewProps>> = ({
   className,
   ItemRenderer = DefaultEditionFilterViewRenderer,

--- a/packages/components/src/EditionTileLink/index.tsx
+++ b/packages/components/src/EditionTileLink/index.tsx
@@ -4,6 +4,7 @@ import { LinkBase } from '../LinkBase';
 import { LinkText } from '../LinkText';
 import { TileBase, useTileState } from '../TileBase';
 import { useImageComponent } from '../ImageProvider';
+import { useBreakpoint } from '../useBreakpoint';
 import styles, { imageRecipe, tileImageRecipe } from './styles.css';
 
 const PseudoLink = ({ children }) => {
@@ -58,27 +59,32 @@ export const EditionTileLink: React.FC<React.PropsWithChildren<EditionTileLinkPr
   description,
   eyebrow = null,
   image,
-  imagePlacement = 'fullWidth',
+  imagePlacement: imagePlacementProp,
   link,
   title,
   ...rest
-}) => (
-  <TileBase className={styles.root} {...rest} size="fullWidth">
-    <LinkBase
-      className={styles.content}
-      aria-labelledby="tilecontent-title"
-      href={link}
-      tabIndex={0}
-    >
-      {image ? <TileImage image={image} imagePlacement={imagePlacement} /> : null}
-      <div>
-        {eyebrow ? <p className={styles.eyebrow}>{eyebrow}</p> : null}
-        {title ? <p className={styles.title}>{title}</p> : null}
-        {description ? <div className={styles.description}>{description}</div> : null}
-        <PseudoLink>
-          <p className={styles.action}>Read More</p>
-        </PseudoLink>
-      </div>
-    </LinkBase>
-  </TileBase>
-);
+}) => {
+  const breakpoint = useBreakpoint();
+  const imagePlacementResponsive = breakpoint === 'mobile' ? 'fullWidth' : 'left';
+  const imagePlacement = imagePlacementProp || imagePlacementResponsive;
+  return (
+    <TileBase className={styles.root} {...rest} size="fullWidth">
+      <LinkBase
+        className={styles.content}
+        aria-labelledby="tilecontent-title"
+        href={link}
+        tabIndex={0}
+      >
+        {image ? <TileImage image={image} imagePlacement={imagePlacement} /> : null}
+        <div>
+          {eyebrow ? <p className={styles.eyebrow}>{eyebrow}</p> : null}
+          {title ? <p className={styles.title}>{title}</p> : null}
+          {description ? <div className={styles.description}>{description}</div> : null}
+          <PseudoLink>
+            <p className={styles.action}>Read More</p>
+          </PseudoLink>
+        </div>
+      </LinkBase>
+    </TileBase>
+  );
+};


### PR DESCRIPTION
Filtering the items in the `EditionFilterView` was throwing the error:

```
`Rendered fewer hooks than expected. This may be caused by an accidental early return statement.
```