### PR TITLE
Reset errors on nav

### DIFF
--- a/.changeset/poor-students-tickle.md
+++ b/.changeset/poor-students-tickle.md
@@ -1,0 +1,10 @@
+---
+'@jpmorganchase/mosaic-site': patch
+'@jpmorganchase/mosaic-site-components': patch
+---
+
+## Feat
+
+Navigating away from a broken page will reset the error status.
+
+This gives more independence to pages, one broken page does not impact the ability to view the other pages on the site.

--- a/packages/site-components/package.json
+++ b/packages/site-components/package.json
@@ -63,7 +63,7 @@
     "next": "^13.4.1",
     "next-mdx-remote": "^4.2.1",
     "node-cookie": "^2.1.2",
-    "react-error-boundary": "^3.1.4",
+    "react-error-boundary": "^4.0.11",
     "react-pro-sidebar": "^1.0.0",
     "rehype-slug": "^5.0.1",
     "swr": "^2.1.2",

--- a/packages/site-components/src/500.tsx
+++ b/packages/site-components/src/500.tsx
@@ -1,7 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Hero } from '@jpmorganchase/mosaic-components';
+import { useErrorBoundary } from 'react-error-boundary';
+import { useRouter } from 'next/router';
 
 export function Page500() {
+  const router = useRouter();
+  const { resetBoundary } = useErrorBoundary();
+
+  useEffect(() => {
+    const handleRouteChange = () => {
+      resetBoundary();
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router]);
+
   return (
     <Hero
       description="A 500 error occurred."

--- a/yarn.lock
+++ b/yarn.lock
@@ -11111,6 +11111,13 @@ react-error-boundary@^3.1.4:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+react-error-boundary@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.11.tgz#36bf44de7746714725a814630282fee83a7c9a1c"
+  integrity sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-immutable-proptypes@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.2.0.tgz#cce96d68cc3c18e89617cbf3092d08e35126af4a"


### PR DESCRIPTION
Currently if you happen to land on a broken page, you are greeted with the Mosaic Error page that asks you to return to the homepage which will reset the error status and allow you to view content again.

But a user can click the back button to a page that was working and will still see the error page.  They can use the sidebar to navigate to another page and will still see the error page.

This change updates the error page so that the error boundary status is reset when the route changes meaning you can navigate away from the broken page and see content again.  A single broken page does not impact the ability to view the working pages on the site without doing a full refresh.