### PR TITLE
fix: ensure `next/font`(s) are applied correctly

### DIFF
--- a/packages/site/src/components/HeadWithFontStyles.tsx
+++ b/packages/site/src/components/HeadWithFontStyles.tsx
@@ -1,0 +1,31 @@
+import Head from 'next/head';
+import { PT_Mono, Open_Sans } from 'next/font/google';
+import type { ReactNode } from 'react';
+import { lightMode, darkMode } from '@jpmorganchase/mosaic-theme';
+
+const ptMono = PT_Mono({
+  weight: '400',
+  display: 'swap',
+  subsets: ['latin']
+});
+const openSans = Open_Sans({
+  subsets: ['latin'],
+  display: 'swap'
+});
+
+export const HeadWithFontStyles = ({ children }: { children: ReactNode }) => (
+  <Head>
+    <style>{`
+      :root {
+        --site-font-family: ${openSans.style.fontFamily};
+        --site-font-family-code: ${ptMono.style.fontFamily};
+      }
+
+      .salt-theme${lightMode}, .salt-theme${darkMode} {
+        --salt-typography-fontFamily: ${openSans.style.fontFamily};
+        --salt-typography-fontFamily-code: ${ptMono.style.fontFamily};
+      }
+    `}</style>
+    {children}
+  </Head>
+);

--- a/packages/site/src/pages/_app.tsx
+++ b/packages/site/src/pages/_app.tsx
@@ -1,6 +1,4 @@
 import { AppProps } from 'next/app';
-import Head from 'next/head';
-import { PT_Mono, Open_Sans } from 'next/font/google';
 import {
   BaseUrlProvider,
   Image,
@@ -17,18 +15,7 @@ import { SessionProvider } from 'next-auth/react';
 import classnames from 'clsx';
 
 import { MyAppProps } from '../types/mosaic';
-
-const ptMono = PT_Mono({
-  weight: '400',
-  variable: '--salt-typography-fontFamily-code',
-  display: 'swap',
-  subsets: ['latin']
-});
-const openSans = Open_Sans({
-  subsets: ['latin'],
-  variable: '--salt-typography-fontFamily',
-  display: 'swap'
-});
+import { HeadWithFontStyles } from '../components/HeadWithFontStyles';
 
 const components = mosaicComponents;
 const layoutComponents = mosaicLayouts;
@@ -41,8 +28,8 @@ export default function MyApp({ Component, pageProps = {} }: AppProps<MyAppProps
   return (
     <SessionProvider>
       <StoreProvider value={createStore()}>
-        <Metadata Component={Head} />
-        <ThemeProvider className={classnames(themeClassName, ptMono.variable, openSans.variable)}>
+        <Metadata Component={HeadWithFontStyles} />
+        <ThemeProvider className={classnames(themeClassName)}>
           <BaseUrlProvider>
             <ImageProvider value={Image}>
               <LinkProvider value={Link}>

--- a/packages/theme/src/baseline/baseline.css.ts
+++ b/packages/theme/src/baseline/baseline.css.ts
@@ -1,8 +1,11 @@
 import { globalStyle } from '@vanilla-extract/css';
 import { ssrClassName } from '../index';
 
+const fallbackFontFamily =
+  '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"';
+
 globalStyle('html, body', {
-  fontFamily: 'Open Sans',
+  fontFamily: `var(--salt-typography-fontFamily, ${fallbackFontFamily})`,
   margin: 0,
   padding: 0,
   height: '100%'


### PR DESCRIPTION
See issue discussed here --> https://github.com/jpmorganchase/salt-ds/issues/2162