### PR TITLE
491 breadcrumbs need to be aware of other sources

### DIFF
--- a/.changeset/tall-otters-scream.md
+++ b/.changeset/tall-otters-scream.md
@@ -1,0 +1,11 @@
+---
+'@jpmorganchase/mosaic-plugins': patch
+'@jpmorganchase/mosaic-site': patch
+'@jpmorganchase/mosaic-types': patch
+---
+
+### Fixes
+
+- Fix types of `IUnionVolume` so that the `promises` property is correct
+
+- Fix Breadcrumb generation so that the global filesystem is used to identify the full breadcrumbs path.

--- a/packages/plugins/src/BreadcrumbsPlugin.ts
+++ b/packages/plugins/src/BreadcrumbsPlugin.ts
@@ -1,7 +1,15 @@
-import path from 'path';
+import path from 'node:path';
+import { escapeRegExp } from 'lodash-es';
 import type { Plugin as PluginType } from '@jpmorganchase/mosaic-types';
 import PluginError from './utils/PluginError.js';
 import { SidebarPluginPage } from './SidebarPlugin.js';
+
+const createPageTest = (ignorePages, pageExtensions) => {
+  const extTest = new RegExp(`${pageExtensions.map(ext => escapeRegExp(ext)).join('|')}$`);
+  const ignoreTest = new RegExp(`${ignorePages.map(ignore => escapeRegExp(ignore)).join('|')}$`);
+  return file =>
+    !ignoreTest.test(file) && extTest.test(file) && !path.basename(file).startsWith('.');
+};
 
 export type Breadcrumb = { label: string; path: string; id: string };
 
@@ -18,8 +26,12 @@ interface BreadcrumbsPluginOptions {
  * Calculates breadcrumbs for pages then embeds a `breadcrumbs` property to the metadata
  */
 const BreadcrumbsPlugin: PluginType<BreadcrumbsPluginPage, BreadcrumbsPluginOptions> = {
-  async $afterSource(pages, _, options) {
+  async $afterSource(pages, { ignorePages, pageExtensions }, options) {
+    const isNonHiddenPage = createPageTest(ignorePages, pageExtensions);
     for (const page of pages) {
+      if (!isNonHiddenPage(page.fullPath)) {
+        continue;
+      }
       try {
         const breadcrumbs: Array<Breadcrumb> = [];
         let currentPage = page;
@@ -53,6 +65,57 @@ const BreadcrumbsPlugin: PluginType<BreadcrumbsPluginPage, BreadcrumbsPluginOpti
     }
 
     return pages;
+  },
+  async afterUpdate(mutableFilesystem, { serialiser, globalFilesystem, ignorePages }, options) {
+    const pages = (await mutableFilesystem.promises.glob('**', {
+      onlyFiles: true,
+      ignore: ignorePages.map(ignore => `**/${ignore}`),
+      cwd: '/'
+    })) as string[];
+
+    if (pages.length > 0) {
+      let updatedBreadcrumbs = [];
+      const { breadcrumbs } = await serialiser.deserialise(
+        pages[0],
+        await mutableFilesystem.promises.readFile(pages[0])
+      );
+
+      // the root breadcrumb is the first breadcrumb for all pages in a source.  It is essentially the "first" page in a source
+      const rootBreadcrumb = breadcrumbs?.[0] || undefined;
+
+      let parentDir = path.posix.join(path.posix.dirname(rootBreadcrumb.id), '../');
+
+      while (parentDir !== '/') {
+        const parentDirIndex = path.posix.join(parentDir, options.indexPageName);
+
+        // check for this file in the global fs so we have a holistic view of all site pages
+        if (await globalFilesystem.promises.exists(parentDirIndex)) {
+          const { breadcrumbs: parentDirBreadcrumbs } = await serialiser.deserialise(
+            rootBreadcrumb.id,
+            await globalFilesystem.promises.readFile(parentDirIndex)
+          );
+          updatedBreadcrumbs = parentDirBreadcrumbs;
+          break;
+        }
+        parentDir = path.posix.join(path.posix.dirname(parentDirIndex), '../');
+      }
+
+      if (updatedBreadcrumbs.length > 0) {
+        for (const pagePath of pages) {
+          const page = await serialiser.deserialise(
+            pagePath,
+            await mutableFilesystem.promises.readFile(pagePath)
+          );
+
+          // append the parent breadcrumbs **before** the current breadcrumbs
+          page.breadcrumbs = [...updatedBreadcrumbs, ...page.breadcrumbs];
+          await mutableFilesystem.promises.writeFile(
+            pagePath,
+            await serialiser.serialise(pagePath, page)
+          );
+        }
+      }
+    }
   }
 };
 

--- a/packages/plugins/src/__tests__/BreadcrumbsPlugin.test.ts
+++ b/packages/plugins/src/__tests__/BreadcrumbsPlugin.test.ts
@@ -61,11 +61,16 @@ describe('GIVEN the BreadcrumbsPlugin', () => {
   let updatedPages: BreadcrumbsPluginPage[] = [];
   beforeEach(async () => {
     const $afterSource = BreadcrumbsPlugin.$afterSource;
-    // @ts-ignore
-    updatedPages = (await $afterSource?.(pages, {}, { indexPageName: 'index.mdx' })) || [];
+    updatedPages =
+      (await $afterSource?.(
+        pages,
+        { ignorePages: ['sidebar.json'], pageExtensions: ['.mdx'] },
+        { indexPageName: 'index.mdx' }
+      )) || [];
   });
+
   test('THEN it should use the `$afterSource` lifecycle event', () => {
-    expect(BreadcrumbsPlugin).toHaveProperty('$afterSource');
+    expect(BreadcrumbsPlugin).toHaveProperty('afterUpdate');
   });
 
   describe('AND WHEN `$afterSource` is called', () => {

--- a/packages/types/src/Volume.ts
+++ b/packages/types/src/Volume.ts
@@ -50,7 +50,7 @@ export interface IVolumePartiallyMutable extends Omit<IVolume, 'reset' | 'fromJS
 }
 
 export interface IUnionVolume extends Omit<IVolumeImmutable, 'promises'> {
-  promises: Pick<IVolumeImmutable, 'promises'> & {
+  promises: Omit<IVolumeImmutable['promises'], 'readFile'> & {
     /**
      * Reads a file
      * @param file Path


### PR DESCRIPTION
The gist of this is:

1. Source A generates its breadcrumbs
2. Source B generates its breadcrumbs
3. Source B is notified that source A has emitted some pages
4. Source B finds its "root breadcrumb" this is the first breadcrumb present in *any* of its pages
5. From the root breadcrumb we traverse up the **global filesystem** to find pages.  This is the key because this traversal will include pages from Source A.
6. We find any additional breadcrumbs that would normally have been created if Source B pages were part of source A
7. We update all pages in Source B with the additional breadcrumbs.


Note that when doing this a bug in the types for `IUnionVolume` was identified which has been resolved as well.