### PR TITLE
Breadcrumbs after update

### DIFF
--- a/.changeset/tall-avocados-repeat.md
+++ b/.changeset/tall-avocados-repeat.md
@@ -1,0 +1,13 @@
+---
+'@jpmorganchase/mosaic-core': patch
+'@jpmorganchase/mosaic-plugins': patch
+'@jpmorganchase/mosaic-types': patch
+---
+
+### Feature
+
+Add new plugin lifecycle method `shouldUpdateNamespaceSources`.
+
+This method is called when a source emits new pages and there is another source(s) that share the same namespace.
+
+If `shouldUpdateNamespaceSources` returns `true` then the other source(s), i.e., not the source that triggered the initial update, will call `afterUpdate` again.

--- a/packages/core/src/Source.ts
+++ b/packages/core/src/Source.ts
@@ -221,13 +221,13 @@ export default class Source {
 
     if (foundWorkflows.length === 0) {
       return {
-        error: `[Mosaic] Workflow ${name} not found for ${this.id.description.toString()}`
+        error: `[Mosaic][Source] workflow ${name} not found for ${this.id.description.toString()}`
       };
     }
 
     if (foundWorkflows.length > 1) {
       return {
-        error: `[Mosaic] Multiple workflows with "${name}" found for ${this.id.description.toString()}`
+        error: `[Mosaic][Source] multiple workflows with "${name}" found for ${this.id.description.toString()}`
       };
     }
 

--- a/packages/core/src/Source.ts
+++ b/packages/core/src/Source.ts
@@ -109,11 +109,7 @@ export default class Source {
    * Called when another source (not this one) has changed.
    * This source can then ask its plugins if they also want to clear their cache in response to the other source's change.
    */
-  async requestCacheClear(
-    updatedSourceFilesystem: IVolumeImmutable,
-    sharedFilesystem: IVolumeImmutable,
-    globalConfig: MutableData<unknown>
-  ) {
+  async requestCacheClear(updatedSourceFilesystem: IVolumeImmutable) {
     const initTime = new Date().getTime();
     const shouldInvokeAfterUpdate = await this.#pluginApi.shouldClearCache(
       updatedSourceFilesystem,
@@ -134,9 +130,37 @@ export default class Source {
     }
     if (shouldInvokeAfterUpdate === true) {
       this.filesystem.clearCache();
+    }
+  }
+
+  async requestNamespaceSourceUpdate(
+    updatedSourceFilesystem: IVolumeImmutable,
+    sharedFilesystem: IVolumeImmutable,
+    globalConfig: MutableData<unknown>
+  ) {
+    const initTime = new Date().getTime();
+    const shouldInvokeAfterUpdate = await this.#pluginApi.shouldUpdateNamespaceSources(
+      updatedSourceFilesystem,
+      {
+        globalFilesystem: this.#globalFilesystem,
+        pageExtensions: this.#pageExtensions,
+        ignorePages: this.#ignorePages,
+        serialiser: this.serialiser,
+        config: this.config.asReadOnly(),
+        namespace: this.namespace
+      }
+    );
+    const timeTaken = new Date().getTime() - initTime;
+    if (timeTaken > 400) {
+      console.warn(
+        `Lifecycle phase 'shouldUpdateNamespaceSources' for source '${this.id.description}' took ${timeTaken}ms to complete. The method is async, so this may not be an accurate measurement of execution time, but consider optimising this method if it is performing intensive operations.`
+      );
+    }
+    if (shouldInvokeAfterUpdate === true) {
       this.filesystem.unfreeze();
       await this.invokeAfterUpdate(sharedFilesystem, globalConfig);
       this.filesystem.freeze();
+      this.filesystem.clearCache();
     }
   }
 

--- a/packages/core/src/Source.ts
+++ b/packages/core/src/Source.ts
@@ -109,7 +109,11 @@ export default class Source {
    * Called when another source (not this one) has changed.
    * This source can then ask its plugins if they also want to clear their cache in response to the other source's change.
    */
-  async requestCacheClear(updatedSourceFilesystem: IVolumeImmutable) {
+  async requestCacheClear(
+    updatedSourceFilesystem: IVolumeImmutable,
+    sharedFilesystem: IVolumeImmutable,
+    globalConfig: MutableData<unknown>
+  ) {
     const initTime = new Date().getTime();
     const shouldInvokeAfterUpdate = await this.#pluginApi.shouldClearCache(
       updatedSourceFilesystem,
@@ -130,6 +134,9 @@ export default class Source {
     }
     if (shouldInvokeAfterUpdate === true) {
       this.filesystem.clearCache();
+      this.filesystem.unfreeze();
+      await this.invokeAfterUpdate(sharedFilesystem, globalConfig);
+      this.filesystem.freeze();
     }
   }
 

--- a/packages/core/src/SourceManager.ts
+++ b/packages/core/src/SourceManager.ts
@@ -151,7 +151,6 @@ export default class SourceManager {
             if (!sourceActive) {
               return;
             }
-
             await source.invokeAfterUpdate(this.#sharedFilesystem, this.#globalConfig);
 
             // After each async operation, we should check if anything has caused the Source to close
@@ -217,7 +216,11 @@ export default class SourceManager {
     return Promise.all(
       Array.from(this.#sources.values()).map(existingSource => {
         if (existingSource !== source && existingSource.filesystem.frozen) {
-          return existingSource.requestCacheClear(immutableSourceFilesystem);
+          return existingSource.requestCacheClear(
+            immutableSourceFilesystem,
+            this.#sharedFilesystem,
+            this.#globalConfig
+          );
         }
         return existingSource;
       })

--- a/packages/core/src/__tests__/SourceManager.test.ts
+++ b/packages/core/src/__tests__/SourceManager.test.ts
@@ -172,7 +172,7 @@ describe('GIVEN SourceManager', () => {
         await expect(() =>
           sourceManager.addSource({ name: 'source2', modulePath: 'source2-module' }, {})
         ).rejects.toThrow(
-          new Error("Source 'source2' received a message before it was initialised.")
+          new Error("[Mosaic][Source] 'source2' received a message before it was initialised.")
         );
       });
 
@@ -242,7 +242,9 @@ describe('GIVEN SourceManager', () => {
         });
         await expect(() =>
           sourceManager.addSource({ name: 'source', modulePath: 'source-module' }, {})
-        ).rejects.toThrow(new Error("Source 'source' silently exited before initialising."));
+        ).rejects.toThrow(
+          new Error("[Mosaic][Source] 'source' silently exited before initialising.")
+        );
       });
       test('THEN the error should be reported in a rejected promise', async () => {
         setTimeout(() => {

--- a/packages/core/src/plugin/createPluginAPI.ts
+++ b/packages/core/src/plugin/createPluginAPI.ts
@@ -37,6 +37,9 @@ function createProxyBaseAPI<ConfigData>(): Plugin<Page, ConfigData> {
     },
     $beforeSend() {
       throw new Error('This is just for the interface on the Proxy and should never be invoked.');
+    },
+    shouldUpdateNamespaceSources() {
+      throw new Error('This is just for the interface on the Proxy and should never be invoked.');
     }
   };
 }

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -58,6 +58,10 @@ export async function bindPluginMethods(
     async $beforeSend(mutableFilesystem, args) {
       const result = await pluginApi.$beforeSend(mutableFilesystem, args);
       return result;
+    },
+    async shouldUpdateNamespaceSources(lastAfterUpdateReturn, args) {
+      const result = await pluginApi.shouldUpdateNamespaceSources(lastAfterUpdateReturn, args);
+      return result;
     }
   };
 }

--- a/packages/core/src/plugin/pluginRunner.ts
+++ b/packages/core/src/plugin/pluginRunner.ts
@@ -35,6 +35,10 @@ export default async function pluginRunner(
       }
 
       transformedInput = result;
+      if (lifecycleName === 'shouldClearCache' && result === true) {
+        /** This lifecycle returns a boolean so if *any* plugin wants to clear the cache then we should do so */
+        break;
+      }
     } catch (exception) {
       const pluginName = path.posix.basename(
         plugin.modulePath,
@@ -63,5 +67,6 @@ export default async function pluginRunner(
       continue;
     }
   }
+
   return { result: transformedInput, errors: pluginErrors };
 }

--- a/packages/core/src/plugin/pluginRunner.ts
+++ b/packages/core/src/plugin/pluginRunner.ts
@@ -28,14 +28,23 @@ export default async function pluginRunner(
         plugin.options
       );
 
-      if (result && lifecycleName !== '$afterSource' && lifecycleName !== 'shouldClearCache') {
+      if (
+        result &&
+        lifecycleName !== '$afterSource' &&
+        lifecycleName !== 'shouldClearCache' &&
+        lifecycleName !== 'shouldUpdateNamespaceSources'
+      ) {
         console.warn(
           `[Mosaic] \`${lifecycleName}\` plugin should not return a value - this lifecycle phase expects mutation to occur directly on the filesystem instance. This will be ignored.`
         );
       }
 
       transformedInput = result;
-      if (lifecycleName === 'shouldClearCache' && result === true) {
+      if (
+        (lifecycleName === 'shouldClearCache' ||
+          lifecycleName === 'shouldUpdateNamespaceSources') &&
+        result === true
+      ) {
         /** This lifecycle returns a boolean so if *any* plugin wants to clear the cache then we should do so */
         break;
       }

--- a/packages/core/src/worker/Source.worker.ts
+++ b/packages/core/src/worker/Source.worker.ts
@@ -90,7 +90,7 @@ if (isMainThread) {
     )
     .subscribe(async (pagesAndSymlinks: Buffer) => {
       if (workerData.options.cache !== false) {
-        console.info(`[Mosaic] Saving cached filesystem of ${workerData.name}`);
+        console.info(`[Mosaic][Source] Saving cached filesystem of ${workerData.name}`);
         await fs.promises.writeFile(cachePath, pagesAndSymlinks);
       }
 
@@ -107,7 +107,7 @@ if (isMainThread) {
     try {
       if (await fs.promises.stat(cachePath)) {
         const data = await fs.promises.readFile(cachePath);
-        console.info(`[Mosaic] Restoring cached filesystem for ${workerData.name}`);
+        console.info(`[Mosaic][Source] Restoring cached filesystem for ${workerData.name}`);
         parentPort.postMessage(
           {
             type: 'init',

--- a/packages/plugins/src/BreadcrumbsPlugin.ts
+++ b/packages/plugins/src/BreadcrumbsPlugin.ts
@@ -118,6 +118,9 @@ const BreadcrumbsPlugin: PluginType<BreadcrumbsPluginPage, BreadcrumbsPluginOpti
         }
       }
     }
+  },
+  async shouldClearCache() {
+    return true;
   }
 };
 

--- a/packages/plugins/src/BreadcrumbsPlugin.ts
+++ b/packages/plugins/src/BreadcrumbsPlugin.ts
@@ -119,7 +119,7 @@ const BreadcrumbsPlugin: PluginType<BreadcrumbsPluginPage, BreadcrumbsPluginOpti
       }
     }
   },
-  async shouldClearCache() {
+  async shouldUpdateNamespaceSources() {
     return true;
   }
 };

--- a/packages/types/src/Plugin.ts
+++ b/packages/types/src/Plugin.ts
@@ -153,4 +153,28 @@ export type Plugin<
     },
     options?: TOptions
   ) => Promise<boolean>;
+  /**
+   * Plugin lifecycle method that triggers inside the main process everytime ANY source emits new pages.
+   * This method should return a boolean that will indicate if this source should force other namespace sources to re-run afterUpdate.
+   * Returning `undefined`, false or no value, will result in no update being triggered for namespace sources
+   * @param updatedSourceFilesystem Immutable filesystem for the source that changed
+   * @param param.config An immutable object for reading data from other lifecycle phases of all plugins for this source in the child process for this plugin
+   * @param param.serialiser A matching `Serialiser` for serialising/deserialising pages when reading/writing to the filesystem
+   * @param param.globalFilesystem Immutable union filesystem instance with all source's pages (and symlinks applied)
+   * @param param.namespace The namespace of the source running the plugin
+   * @param options The options passed in when declaring the plugin
+   * @returns {Promise<boolean>} A boolean indicating whether to clear the cache for this source
+   */
+  shouldUpdateNamespaceSources?: (
+    updatedSourceFilesystem: IVolumeImmutable,
+    helpers: {
+      serialiser: Serialiser<TPage>;
+      config: ImmutableData<ConfigData>;
+      globalFilesystem: IUnionVolume;
+      pageExtensions: string[];
+      ignorePages: string[];
+      namespace: string;
+    },
+    options?: TOptions
+  ) => Promise<boolean>;
 };


### PR DESCRIPTION
Followup to https://github.com/jpmorganchase/mosaic/pull/492

The breadcrumbs were still not showing up from a cold start.

This PR introduces a new plugin lifecycle method `shouldUpdateNamespaceSources`.

When a source updates, **other sources that share the same namespace** will re-run `afterUpdate` if there is any plugin that returns true when `shouldUpdateNamespaceSources` is called.

This allows the other source to have a more holistic view of the namespace pages.
