### PR TITLE
Mosaic fastify

### DIFF
--- a/.changeset/spotty-mice-share.md
+++ b/.changeset/spotty-mice-share.md
@@ -1,0 +1,17 @@
+---
+'@jpmorganchase/mosaic-cli': patch
+'@jpmorganchase/mosaic-plugins': patch
+'@jpmorganchase/mosaic-schemas': patch
+---
+
+### Feat
+
+`enableSourcePush` is now a property of the Mosaic Config file. This functionality was previously configured using an environment variable `process.env.MOSAIC_ENABLE_SOURCE_PUSH`
+
+### Fix
+
+The Admin API that returned the Mosaic config file now strips credentials from git reo sources
+
+### Refactor
+
+Fastify is now used as the web server powering the `serve` functionality of the Mosaic CLI.

--- a/jest.config.server.js
+++ b/jest.config.server.js
@@ -14,6 +14,7 @@ module.exports = {
   setupFilesAfterEnv: ['./scripts/jest/server/jest.environment.js'],
   // Add tests paths to roots
   roots: [
+    '<rootDir>/packages/cli',
     '<rootDir>/packages/core',
     '<rootDir>/packages/fromHttpRequest',
     '<rootDir>/packages/plugins',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,10 +48,11 @@
     "@jpmorganchase/mosaic-standard-generator": "^0.1.0-beta.49",
     "@jpmorganchase/mosaic-source-local-folder": "^0.1.0-beta.49",
     "@aws-sdk/client-s3": "^3.359.0",
+    "@fastify/middie": "^8.3.0",
     "commander": "^9.4.1",
     "cors": "^2.8.5",
     "deepmerge": "^4.2.2",
-    "express": "^4.18.2",
+    "fastify": "^4.23.2",
     "fs-extra": "^10.1.0",
     "globby": "^13.1.3",
     "mkdirp": "^1.0.4"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
     "cors": "^2.8.5",
     "deepmerge": "^4.2.2",
     "fastify": "^4.23.2",
+    "fastify-plugin": "^4.5.1",
     "fs-extra": "^10.1.0",
     "globby": "^13.1.3",
     "mkdirp": "^1.0.4"

--- a/packages/cli/src/__tests__/serve.test.ts
+++ b/packages/cli/src/__tests__/serve.test.ts
@@ -1,0 +1,344 @@
+import type { MosaicConfig } from '@jpmorganchase/mosaic-types';
+import serve, { server } from '../serve';
+
+const mosaicConfig: MosaicConfig = {
+  enableSourcePush: true,
+  schedule: {
+    checkIntervalMins: 60,
+    initialDelayMs: 1000,
+    retryDelayMins: 15,
+    maxRetries: 20,
+    retryEnabled: true,
+    resetOnSuccess: true
+  },
+  pageExtensions: ['.mdx', '.json'],
+  ignorePages: ['shared-config.json', 'sitemap.xml', 'sidebar.json'],
+  serialisers: [],
+  plugins: [],
+  sources: [
+    {
+      modulePath: '@jpmorganchase/mosaic-source-local-folder',
+      namespace: 'mosaic',
+      options: {
+        rootDir: '../../docs',
+        prefixDir: 'mosaic',
+        extensions: ['.mdx']
+      }
+    },
+    {
+      modulePath: '@jpmorganchase/mosaic-source-git-repo',
+      namespace: 'mosaic',
+      options: {
+        credentials: 'david: Password1',
+        prefixDir: 'mosaic/docs',
+        subfolder: 'docs',
+        repo: 'https://repo-url',
+        branch: 'develop',
+        extensions: ['.mdx'],
+        remote: 'origin'
+      }
+    }
+  ]
+};
+
+const mockFilesystemJSON = { '/file/path': { title: 'test 1' } };
+const mockStopSourceFn = jest.fn().mockResolvedValue(true);
+const mockAddSourceFn = jest.fn();
+const mockRestartSourceFn = jest.fn().mockResolvedValue(true);
+const mockListSourcesFn = jest
+  .fn()
+  .mockResolvedValue(mosaicConfig.sources.map((source, index) => ({ index, ...source })));
+
+jest.mock('@jpmorganchase/mosaic-core', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      start: jest.fn(),
+      addSource: mockAddSourceFn,
+      restartSource: mockRestartSourceFn,
+      stopSource: mockStopSourceFn,
+      listSources: mockListSourcesFn,
+      filesystem: { scope: jest.fn(), toJSON: jest.fn().mockReturnValue(mockFilesystemJSON) }
+    };
+  });
+});
+
+describe('GIVEN the serve command', () => {
+  beforeAll(async () => {
+    await serve(mosaicConfig, 8080, undefined /** scope */);
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  test('THEN a mosaic instance is created and available to server plugins', async () => {
+    expect(server.mosaic).toBeDefined();
+    expect(server.mosaic.core).toBeDefined();
+  });
+
+  test('THEN a mosaic filesystem is created and available to server plugins', async () => {
+    expect(server.mosaic.fs).toBeDefined();
+  });
+
+  test('THEN the mosaic config is available to server plugins', async () => {
+    expect(server.mosaic.fs).toBeDefined();
+  });
+
+  test('THEN the config Admin API returns the mosaic config', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/_mosaic_/config'
+    });
+    expect(response.statusCode).toEqual(200);
+    const responseConfig = JSON.parse(response.payload);
+    expect(responseConfig).toEqual(mosaicConfig);
+    expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
+
+    // confirm credentials are sanitized for git repo sources
+    expect(responseConfig.sources[1].options.credentials).toEqual('david: ********');
+  });
+
+  test('THEN the list sources Admin API returns the running sources', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/_mosaic_/sources/list'
+    });
+    expect(mockListSourcesFn).toBeCalledTimes(1);
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
+    const sources = JSON.parse(response.payload);
+    expect(sources).toEqual(mosaicConfig.sources);
+
+    // confirm credentials are sanitized for git repo sources
+    expect(sources[1].options.credentials).toEqual('david: ********');
+  });
+
+  test('THEN the Get Filesystem Admin API returns the current fs content', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/_mosaic_/content/dump'
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(JSON.parse(response.payload)).toEqual(mockFilesystemJSON);
+  });
+
+  test('THEN the Stop Source Admin API stops a source if a valid name is given', async () => {
+    const response = await server.inject({
+      method: 'PUT',
+      url: '/_mosaic_/source/stop',
+      payload: { name: 'stop-me' }
+    });
+
+    expect(mockStopSourceFn).toBeCalledTimes(1);
+    expect(mockStopSourceFn.mock.calls[0][0]).toEqual('stop-me');
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['content-type']).toEqual('application/text');
+    expect(response.payload).toEqual('stop-me stopped successfully.');
+  });
+
+  test('THEN the Stop Source Admin API returns an error if a source name is not provided', async () => {
+    mockStopSourceFn.mockClear();
+    const response = await server.inject({
+      method: 'PUT',
+      url: '/_mosaic_/source/stop',
+      payload: { something: 'stop-me' }
+    });
+
+    expect(mockStopSourceFn).toBeCalledTimes(0);
+    expect(response.statusCode).toEqual(500);
+    expect(response.headers['content-type']).toEqual('application/text');
+    expect(response.payload).toEqual('No source name provided.');
+  });
+
+  test('THEN the Stop Source Admin API returns an error if the source cannot be stopped', async () => {
+    mockStopSourceFn.mockReset();
+    mockStopSourceFn.mockRejectedValueOnce(new Error('oopsy'));
+    const response = await server.inject({
+      method: 'PUT',
+      url: '/_mosaic_/source/stop',
+      payload: { name: 'stop-me' }
+    });
+
+    expect(mockStopSourceFn).toBeCalledTimes(1);
+    expect(response.statusCode).toEqual(500);
+    expect(response.headers['content-type']).toEqual('application/text');
+    expect(response.payload).toEqual('stop-me not stopped.  Check you have the right name!');
+  });
+
+  test('THEN the Restart Source Admin API restarts a source if a valid name is given', async () => {
+    const response = await server.inject({
+      method: 'PUT',
+      url: '/_mosaic_/source/restart',
+      payload: { name: 'restart-me' }
+    });
+
+    expect(mockRestartSourceFn).toBeCalledTimes(1);
+    expect(mockRestartSourceFn.mock.calls[0][0]).toEqual('restart-me');
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['content-type']).toEqual('application/text');
+    expect(response.payload).toEqual('restart-me restarted successfully.');
+  });
+
+  test('THEN the Restart Source Admin API returns an error if a source name is not provided', async () => {
+    mockRestartSourceFn.mockClear();
+    const response = await server.inject({
+      method: 'PUT',
+      url: '/_mosaic_/source/restart',
+      payload: { something: 'restart-me' }
+    });
+
+    expect(mockRestartSourceFn).toBeCalledTimes(0);
+    expect(response.statusCode).toEqual(500);
+    expect(response.headers['content-type']).toEqual('application/text');
+    expect(response.payload).toEqual('No source name provided.');
+  });
+
+  test('THEN the Restart Source Admin API returns an error if the source cannot be stopped', async () => {
+    mockRestartSourceFn.mockReset();
+    mockRestartSourceFn.mockRejectedValueOnce(new Error('oopsy'));
+    const response = await server.inject({
+      method: 'PUT',
+      url: '/_mosaic_/source/restart',
+      payload: { name: 'restart-me' }
+    });
+
+    expect(mockRestartSourceFn).toBeCalledTimes(1);
+    expect(response.statusCode).toEqual(500);
+    expect(response.headers['content-type']).toEqual('application/text');
+    expect(response.payload).toEqual('restart-me not restarted.  Check you have the right name!');
+  });
+
+  describe('AND WHEN source pushing is enabled', () => {
+    beforeEach(() => {
+      mockAddSourceFn.mockClear();
+    });
+
+    test('THEN the Add Source Admin API adds a source when a valid definition is provided', async () => {
+      const payload = {
+        definition: {
+          disabled: false,
+          modulePath: '@jpmorganchase/mosaic-source-local-folder',
+          namespace: 'mosaic',
+          options: {
+            rootDir: '../../docs',
+            prefixDir: 'mosaic',
+            extensions: ['.mdx']
+          }
+        },
+        isPreview: false
+      };
+
+      mockAddSourceFn.mockResolvedValue({
+        ...payload.definition,
+        id: { description: 'added-source' }
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/_mosaic_/source/add',
+        payload
+      });
+
+      expect(mockAddSourceFn).toBeCalledTimes(1);
+      expect(response.statusCode).toEqual(200);
+      expect(response.headers['content-type']).toEqual('application/text');
+      expect(response.payload).toEqual('Source added-source added successfully');
+    });
+
+    test('THEN the Add Source Admin API throws an error when no definition is provided', async () => {
+      const payload = {
+        source: {
+          disabled: false,
+          modulePath: '@jpmorganchase/mosaic-source-local-folder',
+          namespace: 'mosaic',
+          options: {
+            rootDir: '../../docs',
+            prefixDir: 'mosaic',
+            extensions: ['.mdx']
+          }
+        },
+        isPreview: false
+      };
+
+      mockAddSourceFn.mockResolvedValue({
+        ...payload.source,
+        id: { description: 'added-source' }
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/_mosaic_/source/add',
+        payload
+      });
+
+      expect(mockAddSourceFn).toBeCalledTimes(0);
+      expect(response.statusCode).toEqual(500);
+      expect(response.headers['content-type']).toEqual('application/text');
+      expect(response.payload).toEqual('Source definition is required');
+    });
+
+    test('THEN the Add Source Admin API can add preview sources', async () => {
+      const payload = {
+        definition: {
+          disabled: false,
+          modulePath: '@jpmorganchase/mosaic-source-local-folder',
+          namespace: 'mosaic',
+          options: {
+            rootDir: '../../docs',
+            prefixDir: 'mosaic',
+            extensions: ['.mdx']
+          }
+        },
+        isPreview: true
+      };
+
+      mockAddSourceFn.mockResolvedValue({
+        ...payload.definition,
+        id: { description: 'added-source' }
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/_mosaic_/source/add',
+        payload
+      });
+
+      expect(mockAddSourceFn).toBeCalledTimes(1);
+      expect(mockAddSourceFn.mock.calls[0][0].namespace).toEqual('preview-mosaic');
+      expect(response.statusCode).toEqual(200);
+      expect(response.headers['content-type']).toEqual('application/text');
+      expect(response.payload).toEqual('Source added-source added successfully');
+    });
+
+    test('THEN the Add Source Admin API returns an error if the source cannot be added', async () => {
+      mockAddSourceFn.mockRejectedValueOnce(new Error('oopsy'));
+
+      const payload = {
+        definition: {
+          disabled: false,
+          modulePath: '@jpmorganchase/mosaic-source-local-folder',
+          namespace: 'mosaic',
+          options: {
+            rootDir: '../../docs',
+            prefixDir: 'mosaic',
+            extensions: ['.mdx']
+          }
+        },
+        isPreview: false
+      };
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/_mosaic_/source/add',
+        payload
+      });
+
+      expect(mockAddSourceFn).toBeCalledTimes(1);
+      expect(response.statusCode).toEqual(500);
+      expect(response.headers['content-type']).toEqual('application/text');
+      expect(response.payload).toEqual('oopsy');
+    });
+  });
+});

--- a/packages/cli/src/plugins/mosaicAdminPlugin.ts
+++ b/packages/cli/src/plugins/mosaicAdminPlugin.ts
@@ -1,0 +1,160 @@
+import { FastifyInstance, FastifyRequest } from 'fastify';
+import { SourceModuleDefinition } from '@jpmorganchase/mosaic-types';
+import fp from 'fastify-plugin';
+
+export interface FastifyMosaicAdminPluginOptions {
+  prefix: string;
+  enableSourcePush?: boolean;
+}
+
+export interface AdminRequestBodyType {
+  name: string;
+}
+
+interface AddSourceRequestBodyType {
+  definition: SourceModuleDefinition;
+  isPreview?: boolean;
+}
+
+function mosaicAdmin(fastify: FastifyInstance, options: FastifyMosaicAdminPluginOptions, next) {
+  const { prefix } = options;
+  const { config, fs, core } = fastify.mosaic;
+
+  /**
+   * Return the JSON config that Mosaic was started with
+   */
+  fastify.get(`/${prefix}/config`, async (_req, reply) => {
+    reply.header('Content-Type', 'application/json');
+    reply.send(config);
+  });
+
+  /**
+   * Return the filesystem as JSON
+   */
+  fastify.get(`/${prefix}/content/dump`, (_req, reply) => {
+    reply.header('Content-Type', 'application/json');
+    reply.send(fs.toJSON());
+  });
+
+  /**
+   * List the sources that Mosaic has been configured to use.
+   * Will provide the generated name of each source
+   * which can be used to stop/restart the source
+   */
+  fastify.get(`/${prefix}/sources/list`, async (_req, reply) => {
+    reply.header('Content-Type', 'application/json');
+    const sources = await core.listSources();
+
+    const response = sources.map(source => {
+      const sourceFromConfig = config.sources[source.index];
+      const sourceOptions = sourceFromConfig.options as { credentials?: string } | undefined;
+
+      if (
+        sourceOptions?.credentials &&
+        sourceFromConfig.modulePath === '@jpmorganchase/mosaic-source-git-repo'
+      ) {
+        const parts = sourceOptions.credentials?.split(':') || [];
+        if (parts.length > 0) {
+          sourceFromConfig.options = {
+            ...sourceOptions,
+            credentials: `${parts[0]}: ********`
+          };
+        }
+      }
+
+      return {
+        name: source.name,
+        ...sourceFromConfig,
+        pluginErrors: source.pluginErrors
+      };
+    });
+    reply.send(response);
+  });
+
+  /**
+   * Stop a running source using it's generated name
+   */
+  fastify.put(
+    `/${prefix}/source/stop`,
+    async (req: FastifyRequest<{ Body: AdminRequestBodyType }>, reply) => {
+      reply.header('Content-Type', 'application/text');
+      const { name } = req.body;
+      if (name) {
+        try {
+          await core.stopSource(String(name));
+          reply.send(`${name} stopped successfully.`);
+        } catch (e) {
+          console.error(e);
+          reply.status(500).send(`${name} not stopped.  Check you have the right name!`);
+        }
+      }
+    }
+  );
+
+  /**
+   * Restart a running source using it's generated name
+   */
+  fastify.put(
+    `/${prefix}/source/restart`,
+    async (req: FastifyRequest<{ Body: AdminRequestBodyType }>, reply) => {
+      reply.header('Content-Type', 'application/text');
+      const { name } = req.body;
+      if (name) {
+        try {
+          await core.restartSource(String(name));
+          reply.send(`${name} restarted successfully.`);
+        } catch (e) {
+          console.error(e);
+          reply.status(500).send(`${name} not restarted.  Check you have the right name!`);
+        }
+      }
+    }
+  );
+
+  /**
+   * Add a new source
+   */
+  fastify.post(
+    `/${prefix}/source/add`,
+    async (req: FastifyRequest<{ Body: AddSourceRequestBodyType }>, reply) => {
+      try {
+        const { definition, isPreview = true } = req.body;
+
+        if (options.enableSourcePush) {
+          throw new Error('Source push is disabled.');
+        }
+
+        if (!definition) {
+          throw new Error('Source definition is required');
+        }
+
+        if (isPreview) {
+          const namespace = `preview-${definition.namespace}`;
+          definition.namespace = namespace;
+        }
+
+        const source = await core.addSource(definition);
+        reply.send(
+          source !== undefined
+            ? `Source ${source.id.description} added successfully`
+            : 'Unable to add source'
+        );
+      } catch (e) {
+        console.error(e);
+        reply.status(500).send(e.message);
+      }
+    }
+  );
+
+  next();
+}
+
+/**
+ * Fastify plugin that adds support for the Mosaic Admin API routes
+ * https://mosaic-mosaic-dev-team.vercel.app/mosaic/configure/admin/index
+ */
+export default fp(mosaicAdmin, {
+  fastify: '4.x',
+  name: 'fastify-mosaic-admin',
+  dependencies: ['fastify-mosaic']
+});

--- a/packages/cli/src/plugins/mosaicFastifyPlugin.ts
+++ b/packages/cli/src/plugins/mosaicFastifyPlugin.ts
@@ -1,0 +1,71 @@
+import { FastifyInstance } from 'fastify';
+import fp from 'fastify-plugin';
+import MosaicCore from '@jpmorganchase/mosaic-core';
+import { MosaicConfig, IUnionVolume } from '@jpmorganchase/mosaic-types';
+import path from 'node:path';
+
+export interface FastifyMosaicPluginOptions {
+  config: MosaicConfig;
+  scope?: string[];
+}
+
+export interface FastifyMosaic {
+  config: MosaicConfig;
+  core: MosaicCore;
+  fs: IUnionVolume;
+}
+
+async function fastifyMosaic(fastify: FastifyInstance, options: FastifyMosaicPluginOptions) {
+  const { config, scope } = options;
+  const mosaic = new MosaicCore(config);
+  await mosaic.start();
+  const fs = Array.isArray(scope) ? mosaic.filesystem.scope(scope) : mosaic.filesystem;
+  fastify.decorate('mosaic', { config, core: mosaic, fs });
+
+  /**
+   * General content fetch
+   */
+  fastify.get('/*', async (req, reply) => {
+    try {
+      if (await fs.promises.exists(req.url)) {
+        if ((await fs.promises.stat(req.url)).isDirectory()) {
+          if (await fs.promises.exists(path.join(req.url, 'index'))) {
+            // Don't do an actual redirect - just send the URL as the response
+            reply.header('Content-Type', 'application/json');
+            reply.status(302).send({ redirect: path.join(req.url, 'index') });
+          } else {
+            reply.status(404);
+          }
+        } else {
+          const pagePath = await fs.promises.realpath(req.url);
+          if (path.extname(pagePath) === '.mdx') {
+            reply.header('Content-Type', 'text/mdx');
+          } else if (path.extname(pagePath) === '.json') {
+            reply.header('Content-Type', 'application/json');
+          } else if (path.extname(pagePath) === '.xml') {
+            reply.header('Content-Type', 'application/xml');
+          }
+          const result = await fs.promises.readFile(req.url);
+          reply.send(result);
+        }
+      } else {
+        reply.status(404);
+      }
+    } catch (e) {
+      console.error(e);
+      reply.status(500);
+    }
+  });
+}
+
+// Most importantly, use declaration merging to add the custom property to the Fastify type system
+declare module 'fastify' {
+  interface FastifyInstance {
+    mosaic: FastifyMosaic;
+  }
+}
+
+export default fp(fastifyMosaic, {
+  fastify: '4.x',
+  name: 'fastify-mosaic'
+});

--- a/packages/cli/src/plugins/mosaicWorkflowsPlugin.ts
+++ b/packages/cli/src/plugins/mosaicWorkflowsPlugin.ts
@@ -1,0 +1,60 @@
+import { FastifyInstance, FastifyRequest } from 'fastify';
+import fp from 'fastify-plugin';
+import path from 'node:path';
+
+export interface FastifyMosaicAdminPluginOptions {
+  prefix?: string;
+  enableSourcePush?: boolean;
+}
+
+export interface WorkflowRequestBodyType {
+  user: string;
+  route: string;
+  markdown: string;
+  name: string;
+}
+
+function mosaicWorkflows(fastify: FastifyInstance, _options, next) {
+  const { fs, core } = fastify.mosaic;
+
+  /**
+   * Run a workflow
+   */
+  fastify.post(
+    '/workflows',
+    async (req: FastifyRequest<{ Body: WorkflowRequestBodyType }>, reply) => {
+      try {
+        const { user, route: routeReq, markdown, name } = req.body;
+
+        if (!name) {
+          throw new Error('Workflow name is required');
+        }
+
+        if (await fs.promises.exists(routeReq)) {
+          const route = (await fs.promises.stat(routeReq)).isDirectory()
+            ? path.posix.join(routeReq, 'index')
+            : routeReq;
+          const pagePath = (await fs.promises.realpath(route)) as string;
+          const result = await core.triggerWorkflow(name, pagePath, { user, markdown });
+          reply.header('Content-Type', 'application/json');
+          reply.send(result);
+        }
+      } catch (e) {
+        console.error(e);
+        reply.status(500).send(e.message);
+      }
+    }
+  );
+
+  next();
+}
+
+/**
+ * Fastify plugin that adds support for the Mosaic Admin API routes
+ * https://mosaic-mosaic-dev-team.vercel.app/mosaic/configure/admin/index
+ */
+export default fp(mosaicWorkflows, {
+  fastify: '4.x',
+  name: 'fastify-mosaic-workflows',
+  dependencies: ['fastify-mosaic']
+});

--- a/packages/cli/src/serve.ts
+++ b/packages/cli/src/serve.ts
@@ -1,232 +1,28 @@
-import Fastify, { type FastifyRequest } from 'fastify';
+import Fastify from 'fastify';
 import cors from 'cors';
-import path from 'node:path';
-import MosaicCore from '@jpmorganchase/mosaic-core';
-import { MosaicConfig, SourceModuleDefinition } from '@jpmorganchase/mosaic-types';
+import { MosaicConfig } from '@jpmorganchase/mosaic-types';
 import middie from '@fastify/middie';
+
+import fastifyMosaic from './plugins/mosaicFastifyPlugin.js';
+import fastifyMosaicAdmin from './plugins/mosaicAdminPlugin.js';
+import fastifyMosaicWorkflows from './plugins/mosaicWorkflowsPlugin.js';
 
 const MOSAIC_ADMIN_PREFIX = '_mosaic_';
 
-interface AdminRequestBodyType {
-  name: string;
-}
-
-interface AddSourceRequestBodyType {
-  definition: SourceModuleDefinition;
-  isPreview?: boolean;
-}
-
-interface WorkflowRequestBodyType {
-  user: string;
-  route: string;
-  markdown: string;
-  name: string;
-}
-
 export default async function serve(config: MosaicConfig, port: number, scope?: string[]) {
-  /**
-   * Start up Mosaic instance
-   */
-  const mosaic = new MosaicCore(config);
-  await mosaic.start();
-  const fs = Array.isArray(scope) ? mosaic.filesystem.scope(scope) : mosaic.filesystem;
-
   const server = Fastify({
     logger: false
   });
 
   await server.register(middie);
+  await server.register(fastifyMosaic, { config, scope });
+  await server.register(fastifyMosaicWorkflows);
+  await server.register(fastifyMosaicAdmin, {
+    prefix: MOSAIC_ADMIN_PREFIX,
+    enableSourcePush: process.env.MOSAIC_ENABLE_SOURCE_PUSH !== 'true'
+  });
+
   server.use(cors());
-
-  /**
-   * List the sources that Mosaic has been configured to use.
-   * Will provide the generated name of each source
-   * which can be used to stop/restart the source
-   */
-  server.get(`/${MOSAIC_ADMIN_PREFIX}/sources/list`, async (_req, reply) => {
-    reply.header('Content-Type', 'application/json');
-    const sources = await mosaic.listSources();
-
-    const response = sources.map(source => {
-      const sourceFromConfig = config.sources[source.index];
-      const options = sourceFromConfig.options as { credentials?: string } | undefined;
-
-      if (
-        options?.credentials &&
-        sourceFromConfig.modulePath === '@jpmorganchase/mosaic-source-git-repo'
-      ) {
-        const parts = options.credentials?.split(':') || [];
-        if (parts.length > 0) {
-          sourceFromConfig.options = {
-            ...options,
-            credentials: `${parts[0]}: ********`
-          };
-        }
-      }
-
-      return {
-        name: source.name,
-        ...sourceFromConfig,
-        pluginErrors: source.pluginErrors
-      };
-    });
-    reply.send(response);
-  });
-
-  /**
-   * Return the JSON config that Mosaic was started with
-   */
-  server.get(`/${MOSAIC_ADMIN_PREFIX}/config`, async (_req, reply) => {
-    reply.header('Content-Type', 'application/json');
-    reply.send(config);
-  });
-
-  /**
-   * Return the filesystem as JSON
-   */
-  server.get(`/${MOSAIC_ADMIN_PREFIX}/content/dump`, async (_req, reply) => {
-    reply.header('Content-Type', 'application/json');
-    reply.send(fs.toJSON());
-  });
-
-  /**
-   * Stop a running source using it's generated name
-   */
-  server.put(
-    `/${MOSAIC_ADMIN_PREFIX}/source/stop`,
-    async (req: FastifyRequest<{ Body: AdminRequestBodyType }>, reply) => {
-      reply.header('Content-Type', 'application/text');
-      const { name } = req.body;
-      if (name) {
-        try {
-          await mosaic.stopSource(String(name));
-          reply.send(`${name} stopped successfully.`);
-        } catch (e) {
-          console.error(e);
-          reply.status(500).send(`${name} not stopped.  Check you have the right name!`);
-        }
-      }
-    }
-  );
-
-  /**
-   * Restart a running source using it's generated name
-   */
-  server.put(
-    `/${MOSAIC_ADMIN_PREFIX}/source/restart`,
-    async (req: FastifyRequest<{ Body: AdminRequestBodyType }>, reply) => {
-      reply.header('Content-Type', 'application/text');
-      const { name } = req.body;
-      if (name) {
-        try {
-          await mosaic.restartSource(String(name));
-          reply.send(`${name} restarted successfully.`);
-        } catch (e) {
-          console.error(e);
-          reply.status(500).send(`${name} not restarted.  Check you have the right name!`);
-        }
-      }
-    }
-  );
-
-  /**
-   * General content fetch
-   */
-  server.get('/*', async (req, reply) => {
-    try {
-      if (await fs.promises.exists(req.url)) {
-        if ((await fs.promises.stat(req.url)).isDirectory()) {
-          if (await fs.promises.exists(path.join(req.url, 'index'))) {
-            // Don't do an actual redirect - just send the URL as the response
-            reply.header('Content-Type', 'application/json');
-            reply.status(302).send({ redirect: path.join(req.url, 'index') });
-          } else {
-            reply.status(404);
-          }
-        } else {
-          const pagePath = await fs.promises.realpath(req.url);
-          if (path.extname(pagePath) === '.mdx') {
-            reply.header('Content-Type', 'text/mdx');
-          } else if (path.extname(pagePath) === '.json') {
-            reply.header('Content-Type', 'application/json');
-          } else if (path.extname(pagePath) === '.xml') {
-            reply.header('Content-Type', 'application/xml');
-          }
-          const result = await fs.promises.readFile(req.url);
-          reply.send(result);
-        }
-      } else {
-        reply.status(404);
-      }
-    } catch (e) {
-      console.error(e);
-      reply.status(500);
-    }
-  });
-
-  /**
-   * Run a workflow
-   */
-  server.post(
-    '/workflows',
-    async (req: FastifyRequest<{ Body: WorkflowRequestBodyType }>, reply) => {
-      try {
-        const { user, route: routeReq, markdown, name } = req.body;
-
-        if (!name) {
-          throw new Error('Workflow name is required');
-        }
-
-        if (await fs.promises.exists(routeReq)) {
-          const route = (await fs.promises.stat(routeReq)).isDirectory()
-            ? path.posix.join(routeReq, 'index')
-            : routeReq;
-          const pagePath = await fs.promises.realpath(route);
-          const result = await mosaic.triggerWorkflow(name, pagePath, { user, markdown });
-          reply.header('Content-Type', 'application/json');
-          reply.send(result);
-        }
-      } catch (e) {
-        console.error(e);
-        reply.status(500).send(e.message);
-      }
-    }
-  );
-
-  /**
-   * Add a new source
-   */
-  server.post(
-    `/${MOSAIC_ADMIN_PREFIX}/source/add`,
-    async (req: FastifyRequest<{ Body: AddSourceRequestBodyType }>, reply) => {
-      try {
-        const { definition, isPreview = true } = req.body;
-
-        if (process.env.MOSAIC_ENABLE_SOURCE_PUSH !== 'true') {
-          throw new Error('Source push is disabled.');
-        }
-
-        if (!definition) {
-          throw new Error('Source definition is required');
-        }
-
-        if (isPreview) {
-          const namespace = `preview-${definition.namespace}`;
-          definition.namespace = namespace;
-        }
-
-        const source = await mosaic.addSource(definition);
-        reply.send(
-          source !== undefined
-            ? `Source ${source.id.description} added successfully`
-            : 'Unable to add source'
-        );
-      } catch (e) {
-        console.error(e);
-        reply.status(500).send(e.message);
-      }
-    }
-  );
 
   /**
    * Run the server

--- a/packages/cli/src/serve.ts
+++ b/packages/cli/src/serve.ts
@@ -1,33 +1,50 @@
-import express from 'express';
+import Fastify, { type FastifyRequest } from 'fastify';
 import cors from 'cors';
 import path from 'node:path';
 import MosaicCore from '@jpmorganchase/mosaic-core';
-import { MosaicConfig } from '@jpmorganchase/mosaic-types';
+import { MosaicConfig, SourceModuleDefinition } from '@jpmorganchase/mosaic-types';
+import middie from '@fastify/middie';
 
-const app = express();
+const MOSAIC_ADMIN_PREFIX = '_mosaic_';
 
-export default async function serve(config: MosaicConfig, port, scope) {
-  app.listen(port, () => {
-    console.log(
-      `[Mosaic] Listening on port ${port}${
-        Array.isArray(scope) ? ` (scoped to ${scope.join(', ')})` : ''
-      }`
-    );
-  });
+interface AdminRequestBodyType {
+  name: string;
+}
+
+interface AddSourceRequestBodyType {
+  definition: SourceModuleDefinition;
+  isPreview?: boolean;
+}
+
+interface WorkflowRequestBodyType {
+  user: string;
+  route: string;
+  markdown: string;
+  name: string;
+}
+
+export default async function serve(config: MosaicConfig, port: number, scope?: string[]) {
+  /**
+   * Start up Mosaic instance
+   */
   const mosaic = new MosaicCore(config);
   await mosaic.start();
-
   const fs = Array.isArray(scope) ? mosaic.filesystem.scope(scope) : mosaic.filesystem;
 
-  app.use(cors(), express.json());
+  const server = Fastify({
+    logger: false
+  });
+
+  await server.register(middie);
+  server.use(cors());
 
   /**
    * List the sources that Mosaic has been configured to use.
    * Will provide the generated name of each source
    * which can be used to stop/restart the source
    */
-  app.get('/_mosaic_/sources/list', async (_req, res) => {
-    res.contentType('application/json');
+  server.get(`/${MOSAIC_ADMIN_PREFIX}/sources/list`, async (_req, reply) => {
+    reply.header('Content-Type', 'application/json');
     const sources = await mosaic.listSources();
 
     const response = sources.map(source => {
@@ -53,139 +70,179 @@ export default async function serve(config: MosaicConfig, port, scope) {
         pluginErrors: source.pluginErrors
       };
     });
-    res.send(response);
+    reply.send(response);
   });
 
   /**
    * Return the JSON config that Mosaic was started with
    */
-  app.get('/_mosaic_/config', async (_req, res) => {
-    res.contentType('application/json');
-    res.send(config);
+  server.get(`/${MOSAIC_ADMIN_PREFIX}/config`, async (_req, reply) => {
+    reply.header('Content-Type', 'application/json');
+    reply.send(config);
   });
 
   /**
    * Return the filesystem as JSON
    */
-  app.get('/_mosaic_/content/dump', async (_req, res) => {
-    res.contentType('application/json');
-    res.send(fs.toJSON());
+  server.get(`/${MOSAIC_ADMIN_PREFIX}/content/dump`, async (_req, reply) => {
+    reply.header('Content-Type', 'application/json');
+    reply.send(fs.toJSON());
   });
 
   /**
    * Stop a running source using it's generated name
    */
-  app.put('/_mosaic_/source/stop', async (req, res) => {
-    res.contentType('application/text');
-    const { name } = req.body;
-    if (name) {
-      try {
-        await mosaic.stopSource(String(name));
-        res.send(`${name} stopped successfully.`);
-      } catch (e) {
-        console.error(e);
-        res.status(500).send(`${name} not stopped.  Check you have the right name!`);
+  server.put(
+    `/${MOSAIC_ADMIN_PREFIX}/source/stop`,
+    async (req: FastifyRequest<{ Body: AdminRequestBodyType }>, reply) => {
+      reply.header('Content-Type', 'application/text');
+      const { name } = req.body;
+      if (name) {
+        try {
+          await mosaic.stopSource(String(name));
+          reply.send(`${name} stopped successfully.`);
+        } catch (e) {
+          console.error(e);
+          reply.status(500).send(`${name} not stopped.  Check you have the right name!`);
+        }
       }
     }
-  });
+  );
 
   /**
    * Restart a running source using it's generated name
    */
-  app.put('/_mosaic_/source/restart', async (req, res) => {
-    res.contentType('application/text');
-    const { name } = req.body;
-    if (name) {
-      try {
-        await mosaic.restartSource(String(name));
-        res.send(`${name} restarted successfully.`);
-      } catch (e) {
-        console.error(e);
-        res.status(500).send(`${name} not restarted.  Check you have the right name!`);
+  server.put(
+    `/${MOSAIC_ADMIN_PREFIX}/source/restart`,
+    async (req: FastifyRequest<{ Body: AdminRequestBodyType }>, reply) => {
+      reply.header('Content-Type', 'application/text');
+      const { name } = req.body;
+      if (name) {
+        try {
+          await mosaic.restartSource(String(name));
+          reply.send(`${name} restarted successfully.`);
+        } catch (e) {
+          console.error(e);
+          reply.status(500).send(`${name} not restarted.  Check you have the right name!`);
+        }
       }
     }
-  });
+  );
 
-  app.get('/**', async (req, res) => {
+  /**
+   * General content fetch
+   */
+  server.get('/*', async (req, reply) => {
     try {
-      if (await fs.promises.exists(req.path)) {
-        if ((await fs.promises.stat(req.path)).isDirectory()) {
-          if (await fs.promises.exists(path.join(req.path, 'index'))) {
+      if (await fs.promises.exists(req.url)) {
+        if ((await fs.promises.stat(req.url)).isDirectory()) {
+          if (await fs.promises.exists(path.join(req.url, 'index'))) {
             // Don't do an actual redirect - just send the URL as the response
-            res.status(302).json({ redirect: path.join(req.path, 'index') });
+            reply.header('Content-Type', 'application/json');
+            reply.status(302).send({ redirect: path.join(req.url, 'index') });
           } else {
-            res.status(404).end();
+            reply.status(404);
           }
         } else {
-          const pagePath = await fs.promises.realpath(req.path);
+          const pagePath = await fs.promises.realpath(req.url);
           if (path.extname(pagePath) === '.mdx') {
-            res.contentType('text/mdx');
+            reply.header('Content-Type', 'text/mdx');
           } else if (path.extname(pagePath) === '.json') {
-            res.contentType('application/json');
+            reply.header('Content-Type', 'application/json');
           } else if (path.extname(pagePath) === '.xml') {
-            res.contentType('application/xml');
+            reply.header('Content-Type', 'application/xml');
           }
-          const result = await fs.promises.readFile(req.path);
-          res.send(result);
+          const result = await fs.promises.readFile(req.url);
+          reply.send(result);
         }
       } else {
-        res.status(404).end();
+        reply.status(404);
       }
     } catch (e) {
       console.error(e);
-      res.status(500).end();
+      reply.status(500);
     }
   });
 
-  app.post('/workflows', async (req, res) => {
-    try {
-      const { user, route: routeReq, markdown, name } = req.body;
+  /**
+   * Run a workflow
+   */
+  server.post(
+    '/workflows',
+    async (req: FastifyRequest<{ Body: WorkflowRequestBodyType }>, reply) => {
+      try {
+        const { user, route: routeReq, markdown, name } = req.body;
 
-      if (!name) {
-        throw new Error('Workflow name is required');
-      }
+        if (!name) {
+          throw new Error('Workflow name is required');
+        }
 
-      if (await fs.promises.exists(routeReq)) {
-        const route = (await fs.promises.stat(routeReq)).isDirectory()
-          ? path.posix.join(routeReq, 'index')
-          : routeReq;
-        const pagePath = await fs.promises.realpath(route);
-        const result = await mosaic.triggerWorkflow(name, pagePath, { user, markdown });
-        res.contentType('application/json');
-        res.send(result);
+        if (await fs.promises.exists(routeReq)) {
+          const route = (await fs.promises.stat(routeReq)).isDirectory()
+            ? path.posix.join(routeReq, 'index')
+            : routeReq;
+          const pagePath = await fs.promises.realpath(route);
+          const result = await mosaic.triggerWorkflow(name, pagePath, { user, markdown });
+          reply.header('Content-Type', 'application/json');
+          reply.send(result);
+        }
+      } catch (e) {
+        console.error(e);
+        reply.status(500).send(e.message);
       }
-    } catch (e) {
-      console.error(e);
-      res.status(500).send(e.message).end();
     }
-  });
+  );
 
-  app.post('/sources/add', async (req, res) => {
+  /**
+   * Add a new source
+   */
+  server.post(
+    `/${MOSAIC_ADMIN_PREFIX}/source/add`,
+    async (req: FastifyRequest<{ Body: AddSourceRequestBodyType }>, reply) => {
+      try {
+        const { definition, isPreview = true } = req.body;
+
+        if (process.env.MOSAIC_ENABLE_SOURCE_PUSH !== 'true') {
+          throw new Error('Source push is disabled.');
+        }
+
+        if (!definition) {
+          throw new Error('Source definition is required');
+        }
+
+        if (isPreview) {
+          const namespace = `preview-${definition.namespace}`;
+          definition.namespace = namespace;
+        }
+
+        const source = await mosaic.addSource(definition);
+        reply.send(
+          source !== undefined
+            ? `Source ${source.id.description} added successfully`
+            : 'Unable to add source'
+        );
+      } catch (e) {
+        console.error(e);
+        reply.status(500).send(e.message);
+      }
+    }
+  );
+
+  /**
+   * Run the server
+   */
+  const start = async () => {
     try {
-      const { definition, isPreview = true } = req.body;
-
-      if (process.env.MOSAIC_ENABLE_SOURCE_PUSH !== 'true') {
-        throw new Error('Source push is disabled.');
-      }
-
-      if (!definition) {
-        throw new Error('Source definition is required');
-      }
-
-      if (isPreview) {
-        const namespace = `preview-${definition.namespace}`;
-        definition.namespace = namespace;
-      }
-
-      const source = await mosaic.addSource(definition);
-      res.send(
-        source !== undefined
-          ? `Source ${source.id.description} added successfully`
-          : 'Unable to add source'
+      await server.listen({ port });
+      console.log(
+        `[Mosaic] Listening on port ${port}${
+          Array.isArray(scope) ? ` (scoped to ${scope.join(', ')})` : ''
+        }`
       );
-    } catch (e) {
-      console.error(e);
-      res.status(500).send(e.message).end();
+    } catch (err) {
+      server.log.error(err);
+      process.exit(1);
     }
-  });
+  };
+  start();
 }

--- a/packages/cli/src/serve.ts
+++ b/packages/cli/src/serve.ts
@@ -9,17 +9,17 @@ import fastifyMosaicWorkflows from './plugins/mosaicWorkflowsPlugin.js';
 
 const MOSAIC_ADMIN_PREFIX = '_mosaic_';
 
-export default async function serve(config: MosaicConfig, port: number, scope?: string[]) {
-  const server = Fastify({
-    logger: false
-  });
+export const server = Fastify({
+  logger: false
+});
 
+export default async function serve(config: MosaicConfig, port: number, scope?: string[]) {
   await server.register(middie);
   await server.register(fastifyMosaic, { config, scope });
   await server.register(fastifyMosaicWorkflows);
   await server.register(fastifyMosaicAdmin, {
     prefix: MOSAIC_ADMIN_PREFIX,
-    enableSourcePush: process.env.MOSAIC_ENABLE_SOURCE_PUSH !== 'true'
+    enableSourcePush: config.enableSourcePush
   });
 
   server.use(cors());
@@ -40,5 +40,5 @@ export default async function serve(config: MosaicConfig, port: number, scope?: 
       process.exit(1);
     }
   };
-  start();
+  await start();
 }

--- a/packages/plugins/src/__tests__/BreadcrumbsPlugin.test.ts
+++ b/packages/plugins/src/__tests__/BreadcrumbsPlugin.test.ts
@@ -1,4 +1,3 @@
-import { serialize } from 'v8';
 import BreadcrumbsPlugin, { BreadcrumbsPluginPage } from '../BreadcrumbsPlugin';
 
 const pages: BreadcrumbsPluginPage[] = [

--- a/packages/schemas/src/MosaicConfigSchema.ts
+++ b/packages/schemas/src/MosaicConfigSchema.ts
@@ -24,7 +24,12 @@ export const mosaicConfigSchema = z.object({
   schedule: sourceScheduleSchema.optional().default({
     checkIntervalMins: 30,
     initialDelayMs: 1000
-  })
+  }),
+  /**
+   * If true, allows source definitions to be pushed to Mosaic on demand.
+   * Only 'remote' source definitions will work as these will pull in the content from a remote source
+   */
+  enableSourcePush: z.boolean().optional().default(false)
 });
 
 export type MosaicConfig = z.infer<typeof mosaicConfigSchema>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6896,7 +6896,7 @@ fast-xml-parser@4.2.5:
   dependencies:
     strnum "^1.0.5"
 
-fastify-plugin@^4.0.0:
+fastify-plugin@^4.0.0, fastify-plugin@^4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-4.5.1.tgz#44dc6a3cc2cce0988bc09e13f160120bbd91dbee"
   integrity sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1942,6 +1942,42 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fastify/ajv-compiler@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@fastify/ajv-compiler/-/ajv-compiler-3.5.0.tgz#459bff00fefbf86c96ec30e62e933d2379e46670"
+  integrity sha512-ebbEtlI7dxXF5ziNdr05mOY8NnDiPB1XvAlLHctRt/Rc+C3LCOVW5imUVX+mhvUhnNzmPBHewUkOFgGlCxgdAA==
+  dependencies:
+    ajv "^8.11.0"
+    ajv-formats "^2.1.1"
+    fast-uri "^2.0.0"
+
+"@fastify/deepmerge@^1.0.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@fastify/deepmerge/-/deepmerge-1.3.0.tgz#8116858108f0c7d9fd460d05a7d637a13fe3239a"
+  integrity sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==
+
+"@fastify/error@^3.2.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@fastify/error/-/error-3.3.0.tgz#eba790082e1144bfc8def0c2c8ef350064bc537b"
+  integrity sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==
+
+"@fastify/fast-json-stringify-compiler@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz#5df89fa4d1592cbb8780f78998355feb471646d5"
+  integrity sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==
+  dependencies:
+    fast-json-stringify "^5.7.0"
+
+"@fastify/middie@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@fastify/middie/-/middie-8.3.0.tgz#1325e9e4373c98d69366d1e38211337dee1b9ccd"
+  integrity sha512-h+zBxCzMlkEkh4fM7pZaSGzqS7P9M0Z6rXnWPdUEPfe7x1BCj++wEk/pQ5jpyYY4pF8AknFqb77n7uwh8HdxEA==
+  dependencies:
+    "@fastify/error" "^3.2.0"
+    fastify-plugin "^4.0.0"
+    path-to-regexp "^6.1.0"
+    reusify "^1.0.4"
+
 "@floating-ui/core@^1.2.6":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.6.tgz#d21ace437cc919cdd8f1640302fa8851e65e75c0"
@@ -4029,6 +4065,18 @@ abab@^2.0.6:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
+abstract-logging@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/abstract-logging/-/abstract-logging-2.0.1.tgz#6b0c371df212db7129b57d2e7fcf282b8bf1c839"
+  integrity sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==
+
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -4113,6 +4161,13 @@ ahocorasick@1.0.2:
   resolved "https://registry.yarnpkg.com/ahocorasick/-/ahocorasick-1.0.2.tgz#9eee93aef9d02bfb476d9b648d9b7a40ef2fd500"
   integrity sha512-hCOfMzbFx5IDutmWLAt6MZwOUjIfSM9G9FyVxytmE4Rs/5YDPWQrD/+IR1w+FweD9H2oOZEnv36TmkjhNURBVA==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -4121,6 +4176,16 @@ ajv@^6.10.0, ajv@^6.12.4:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.10.0, ajv@^8.11.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
@@ -4186,6 +4251,11 @@ anymatch@^3.0.3, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+  integrity sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==
 
 arg@^4.1.0:
   version "4.1.3"
@@ -4329,6 +4399,11 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha1-YCzUtG6EStTv/JKoARo8RuAjjcI=
 
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
+
 attr-accept@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
@@ -4345,6 +4420,15 @@ available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+avvio@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/avvio/-/avvio-8.2.1.tgz#b5a482729847abb84d5aadce06511c04a0a62f82"
+  integrity sha512-TAlMYvOuwGyLK3PfBb5WKBXZmXz2fVCgv23d6zZFdle/q3gPjmxBaeuC0pY0Dzs5PWMSgfqqEZkrye19GlDTgw==
+  dependencies:
+    archy "^1.0.0"
+    debug "^4.0.0"
+    fastq "^1.6.1"
 
 aws-sdk-client-mock@^2.0.1:
   version "2.0.1"
@@ -4518,24 +4602,6 @@ body-parser@1.20.0:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-body-parser@1.20.1:
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
-  integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
-  dependencies:
-    bytes "3.1.2"
-    content-type "~1.0.4"
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "1.2.0"
-    http-errors "2.0.0"
-    iconv-lite "0.4.24"
-    on-finished "2.4.1"
-    qs "6.11.0"
-    raw-body "2.5.1"
-    type-is "~1.6.18"
-    unpipe "1.0.0"
-
 bowser@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
@@ -4622,6 +4688,14 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 busboy@1.6.0:
   version "1.6.0"
@@ -6587,6 +6661,11 @@ event-target-polyfill@^0.0.3:
   resolved "https://registry.yarnpkg.com/event-target-polyfill/-/event-target-polyfill-0.0.3.tgz#ed373295f3b257774b5d75afb2599331d9f3406c"
   integrity sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -6698,43 +6777,6 @@ express@^4.17.1:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-express@^4.18.2:
-  version "4.18.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
-  integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==
-  dependencies:
-    accepts "~1.3.8"
-    array-flatten "1.1.1"
-    body-parser "1.20.1"
-    content-disposition "0.5.4"
-    content-type "~1.0.4"
-    cookie "0.5.0"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "2.0.0"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "1.2.0"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "2.4.1"
-    parseurl "~1.3.3"
-    path-to-regexp "0.1.7"
-    proxy-addr "~2.0.7"
-    qs "6.11.0"
-    range-parser "~1.2.1"
-    safe-buffer "5.2.1"
-    send "0.18.0"
-    serve-static "1.15.0"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    type-is "~1.6.18"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
-
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -6760,6 +6802,16 @@ external-editor@^3.0.3, external-editor@^3.1.0:
     chardet "^0.7.0"
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
+
+fast-content-type-parse@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz#4087162bf5af3294d4726ff29b334f72e3a1092c"
+  integrity sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ==
+
+fast-decode-uri-component@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
+  integrity sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -6803,10 +6855,39 @@ fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=
 
+fast-json-stringify@^5.7.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-5.8.0.tgz#b229ed01ac5f92f3b82001a916c31324652f46d7"
+  integrity sha512-VVwK8CFMSALIvt14U8AvrSzQAwN/0vaVRiFFUVlpnXSnDGrSkOAO5MtzyN8oQNjLd5AqTW5OZRgyjoNuAuR3jQ==
+  dependencies:
+    "@fastify/deepmerge" "^1.0.0"
+    ajv "^8.10.0"
+    ajv-formats "^2.1.1"
+    fast-deep-equal "^3.1.3"
+    fast-uri "^2.1.0"
+    rfdc "^1.2.0"
+
 fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-querystring@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-querystring/-/fast-querystring-1.1.2.tgz#a6d24937b4fc6f791b4ee31dcb6f53aeafb89f53"
+  integrity sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==
+  dependencies:
+    fast-decode-uri-component "^1.0.1"
+
+fast-redact@^3.1.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.3.0.tgz#7c83ce3a7be4898241a46560d51de10f653f7634"
+  integrity sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==
+
+fast-uri@^2.0.0, fast-uri@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-2.2.0.tgz#519a0f849bef714aad10e9753d69d8f758f7445a"
+  integrity sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==
 
 fast-xml-parser@4.2.5:
   version "4.2.5"
@@ -6815,10 +6896,44 @@ fast-xml-parser@4.2.5:
   dependencies:
     strnum "^1.0.5"
 
+fastify-plugin@^4.0.0:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-4.5.1.tgz#44dc6a3cc2cce0988bc09e13f160120bbd91dbee"
+  integrity sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==
+
+fastify@^4.23.2:
+  version "4.23.2"
+  resolved "https://registry.yarnpkg.com/fastify/-/fastify-4.23.2.tgz#7072f04b544540d2523afb4a54d4095d187f5444"
+  integrity sha512-WFSxsHES115svC7NrerNqZwwM0UOxbC/P6toT9LRHgAAFvG7o2AN5W+H4ihCtOGuYXjZf4z+2jXC89rVEoPWOA==
+  dependencies:
+    "@fastify/ajv-compiler" "^3.5.0"
+    "@fastify/error" "^3.2.0"
+    "@fastify/fast-json-stringify-compiler" "^4.3.0"
+    abstract-logging "^2.0.1"
+    avvio "^8.2.1"
+    fast-content-type-parse "^1.0.0"
+    fast-json-stringify "^5.7.0"
+    find-my-way "^7.6.0"
+    light-my-request "^5.9.1"
+    pino "^8.12.0"
+    process-warning "^2.2.0"
+    proxy-addr "^2.0.7"
+    rfdc "^1.3.0"
+    secure-json-parse "^2.5.0"
+    semver "^7.5.0"
+    toad-cache "^3.2.0"
+
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
   integrity sha1-YWdg+Ip1Jr38WWt8q4wYk4w2uYw=
+  dependencies:
+    reusify "^1.0.4"
+
+fastq@^1.6.1:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
+  integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
   dependencies:
     reusify "^1.0.4"
 
@@ -6869,6 +6984,15 @@ finalhandler@1.2.0:
     parseurl "~1.3.3"
     statuses "2.0.1"
     unpipe "~1.0.0"
+
+find-my-way@^7.6.0:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/find-my-way/-/find-my-way-7.6.2.tgz#4dd40200d3536aeef5c7342b10028e04cf79146c"
+  integrity sha512-0OjHn1b1nCX3eVbm9ByeEHiscPYiHLfhei1wOUU9qffQkk98wE0Lo8VrVYfSGMgnSnDh86DxedduAnBf4nwUEw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-querystring "^1.0.0"
+    safe-regex2 "^2.0.0"
 
 find-root@^1.1.0:
   version "1.1.0"
@@ -8747,6 +8871,15 @@ lexical@^0.11.1:
   resolved "https://registry.yarnpkg.com/lexical/-/lexical-0.11.1.tgz#a4ca061c16d9798b3c0b9f2f8e89cc077385e4ea"
   integrity sha512-PhAGADxqzwJldmkVK5tvkaARTULCdeJjfhxWTnJQXTAlApE9heJir7SWxbxeUx1G5gdKZQFicGhOQlDXJmma2Q==
 
+light-my-request@^5.9.1:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/light-my-request/-/light-my-request-5.11.0.tgz#90e446c303b3a47b59df38406d5f5c2cf224f2d1"
+  integrity sha512-qkFCeloXCOMpmEdZ/MV91P8AT4fjwFXWaAFz3lUeStM8RcoM1ks4J/F8r1b3r6y/H4u3ACEJ1T+Gv5bopj7oDA==
+  dependencies:
+    cookie "^0.5.0"
+    process-warning "^2.0.0"
+    set-cookie-parser "^2.4.1"
+
 lilconfig@2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz#19e57fd06ccc3848fd1891655b5a447092225b25"
@@ -10345,6 +10478,11 @@ oidc-token-hash@^5.0.1:
   resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz#ae6beec3ec20f0fd885e5400d175191d6e2f10c6"
   integrity sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==
 
+on-exit-leak-free@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.1.tgz#762dc7db809fa43303e64024f0ea0af54dd81294"
+  integrity sha512-IPTBZ175tI0sSg0ikDcCDfa5dPgcFbJgABsTHsY+Mkdm6Y2VKGuchubXSvTuu5tSPl4mqt53o3nLI74HTs8UgQ==
+
 on-finished@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
@@ -10681,7 +10819,7 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
-path-to-regexp@^6.2.0:
+path-to-regexp@^6.1.0, path-to-regexp@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
   integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
@@ -10735,6 +10873,36 @@ pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+pino-abstract-transport@v1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz#083d98f966262164504afb989bccd05f665937a8"
+  integrity sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==
+  dependencies:
+    readable-stream "^4.0.0"
+    split2 "^4.0.0"
+
+pino-std-serializers@^6.0.0:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz#d9a9b5f2b9a402486a5fc4db0a737570a860aab3"
+  integrity sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==
+
+pino@^8.12.0:
+  version "8.15.3"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-8.15.3.tgz#8d5d9b440f0218e8c03926d8f2e5bd0854c716eb"
+  integrity sha512-wDds1+DH8VaREe4fpLEKttGnDoLiX3KR3AP5bHsrRwEZ93y+Z/HFC03zkGSxpIGWKDHg24sloVqGcIWoLCkTLQ==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    fast-redact "^3.1.1"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport v1.1.0
+    pino-std-serializers "^6.0.0"
+    process-warning "^2.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^3.1.0"
+    thread-stream "^2.0.0"
 
 pirates@^4.0.4:
   version "4.0.5"
@@ -10876,6 +11044,11 @@ prismjs@~1.27.0:
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
+process-warning@^2.0.0, process-warning@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-2.2.0.tgz#008ec76b579820a8e5c35d81960525ca64feb626"
+  integrity sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==
+
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
@@ -10925,7 +11098,7 @@ property-information@^6.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.2.0.tgz#b74f522c31c097b5149e3c3cb8d7f3defd986a1d"
   integrity sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==
 
-proxy-addr@~2.0.7:
+proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
   integrity sha1-8Z/mnOqzEe65S0LnDowgcPm6ECU=
@@ -10973,7 +11146,7 @@ qs@6.10.3:
   dependencies:
     side-channel "^1.0.4"
 
-qs@6.11.0, qs@^6.10.2:
+qs@^6.10.2:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
@@ -10994,6 +11167,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha1-SSkii7xyTfrEPg77BYyve2z7YkM=
+
+quick-format-unescaped@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
+  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
 
 quick-lru@^4.0.1:
   version "4.0.1"
@@ -11359,6 +11537,17 @@ readable-stream@^3.4.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-stream@^4.0.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.4.2.tgz#e6aced27ad3b9d726d8308515b9a1b98dc1b9d13"
+  integrity sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==
+  dependencies:
+    abort-controller "^3.0.0"
+    buffer "^6.0.3"
+    events "^3.3.0"
+    process "^0.11.10"
+    string_decoder "^1.3.0"
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -11370,6 +11559,11 @@ reading-time@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/reading-time/-/reading-time-1.5.0.tgz#d2a7f1b6057cb2e169beaf87113cc3411b5bc5bb"
   integrity sha1-0qfxtgV8suFpvq+HETzDQRtbxbs=
+
+real-require@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
+  integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -11706,7 +11900,7 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
-ret@^0.2.0:
+ret@^0.2.0, ret@~0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.2.2.tgz#b6861782a1f4762dce43402a71eb7a283f44573c"
   integrity sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==
@@ -11716,7 +11910,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=
 
-rfdc@^1.3.0:
+rfdc@^1.2.0, rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
@@ -11809,6 +12003,18 @@ safe-regex-test@^1.0.0:
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
 
+safe-regex2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex2/-/safe-regex2-2.0.0.tgz#b287524c397c7a2994470367e0185e1916b1f5b9"
+  integrity sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==
+  dependencies:
+    ret "~0.2.0"
+
+safe-stable-stringify@^2.3.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
+  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
+
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -11841,6 +12047,11 @@ section-matter@^1.0.0:
     extend-shallow "^2.0.1"
     kind-of "^6.0.0"
 
+secure-json-parse@^2.5.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
+  integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
+
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
@@ -11851,7 +12062,7 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -11907,6 +12118,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz#131921e50f62ff1a66a461d7d62d7b21d5d15a51"
+  integrity sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==
 
 set-cookie-parser@^2.4.6:
   version "2.5.1"
@@ -12087,6 +12303,13 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
+sonic-boom@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-3.4.0.tgz#8582d1385ea3bf79ca953329043bfbdbabe58eb9"
+  integrity sha512-zSe9QQW30nPzjkSJ0glFQO5T9lHsk39tz+2bAAwCj8CNgEG8ItZiX7Wb2ZgA8I04dwRGCcf1m3ABJa8AYm12Fw==
+  dependencies:
+    atomic-sleep "^1.0.0"
+
 source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
@@ -12181,6 +12404,11 @@ split.js@^1.6.0:
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/split.js/-/split.js-1.6.5.tgz#f7f61da1044c9984cb42947df4de4fadb5a3f300"
   integrity sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw==
+
+split2@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -12309,7 +12537,7 @@ string.prototype.trimstart@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.19.5"
 
-string_decoder@^1.1.1:
+string_decoder@^1.1.1, string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
@@ -12594,6 +12822,13 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+thread-stream@^2.0.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-2.4.0.tgz#5def29598d1d4171ba3bace7e023a71d87d99c07"
+  integrity sha512-xZYtOtmnA63zj04Q+F9bdEay5r47bvpo1CaNqsKi7TpoJHcotUez8Fkfo2RJWpW91lnnaApdpRbVwCWsy+ifcw==
+  dependencies:
+    real-require "^0.2.0"
+
 through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -12634,6 +12869,11 @@ to-regex-range@^5.0.1:
   integrity sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=
   dependencies:
     is-number "^7.0.0"
+
+toad-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/toad-cache/-/toad-cache-3.2.0.tgz#8221a1906ce7bd18cd56b22f5603bcf9e38b54f9"
+  integrity sha512-Hj5zSqBS6OHbZoQk9IU8VqIr+0JUpwzunnwSlFJhG8aJSInYUMEuzItl3kJsGteTPd1qtflafdRHlRtUazYeqg==
 
 toggle-selection@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
This PR replaces the [Express](https://expressjs.com/) web framework that powers the `serve` feature of the Mosaic CLI with [fastify](https://fastify.dev/)

## Why?

1.  It's a good bit faster --> https://fastify.dev/benchmarks
2. It has a very nice plugin architecture --> https://fastify.dev/docs/latest/Reference/Plugins/#plugins
3. Better TypeScript support
4. It can be configured to support Express middleware (but we only use CORS middleware so not a big deal for us) --> https://github.com/fastify/fastify-express

## Serve Refactor
 The `serve` function is basically now the place where we register the Mosaic fastify plugins and start listening for requests.  Routes and instantiating Mosaic are done in fastify plugins.

### `mosaicFastifyPlugin`

This plugin instantiates Mosaic and adds a `mosaic` property to the fastify instance.  This allows plugins to access mosaic `core`, the scoped `filesystem` and the mosaic `config` file.

It also sets up the catch-all route used for retrieving pages from the mosaic filesystem.

### `mosaicAdminPlugin`
This plugin depends on the `mosaicFastifyPlugin` and sets up route handlers for all mosaic [Admin APIs](https://mosaic-mosaic-dev-team.vercel.app/mosaic/configure/admin/index).

### `mosaicWorkflowsPlugin`
This plugin depends on the `mosaicFastifyPlugin` and sets up route handler for Mosaic workflows.