### PR TITLE
feat: provide advanced sorting for Sidebar

### DIFF
--- a/.changeset/ninety-coins-fetch.md
+++ b/.changeset/ninety-coins-fetch.md
@@ -1,0 +1,35 @@
+---
+'@jpmorganchase/mosaic-plugins': patch
+'@jpmorganchase/mosaic-site': patch
+---
+
+## Feature - Advanced Sidebar Sorting
+
+Given a directory of pages, you can provide a sidebar sort config in the frontmatter of the directory index page which will be used to sort the other pages in the directory.
+
+The sort config consists of:
+
+- field: the path, separated by a '/', to the page metadata you want to use for sorting e.g. title or data/publicationDate
+- dataType: 'string' or 'number' or 'Date'
+- arrange: 'asc' or 'desc'
+
+Note that a page can still specify its sidebar priority and this will overrule any sort config specified in the index page.
+
+## Example
+
+Let's say you have a "Newsletters" directory which has an index page and multiple newsletter pages in the same directory.
+
+Each newsletter page has a data property which includes the publication date of the newsletter.
+
+To order the newsletters in the sidebar in descending order (the newest newsletter first):
+
+Add the following to the **index** page frontmatter:
+
+```
+sharedConfig:
+  sidebar:
+    sort:
+      field: data/publicationDate
+      dataType: date
+      arrange: desc
+```

--- a/packages/plugins/src/utils/__tests__/sortSidebarData.test.ts
+++ b/packages/plugins/src/utils/__tests__/sortSidebarData.test.ts
@@ -1,0 +1,615 @@
+import { type SidebarDataNode, sortSidebarData } from '../sortSidebarData.js';
+
+describe('GIVEN the sortSidebarData comparator', () => {
+  describe('WHEN pages have a shared sort config', () => {
+    describe('AND WHEN sorting by a date in descending order', () => {
+      const data: SidebarDataNode[] = [
+        {
+          id: 'index',
+          fullPath: 'fullPath',
+          name: 'index page',
+          priority: undefined,
+          data: { level: 3, link: '/index' },
+          childNodes: [
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '01 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'date',
+                arrange: 'desc',
+                fieldData: new Date('01 Jan 2023').getTime()
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '05 May 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'date',
+                arrange: 'desc',
+                fieldData: new Date('05 May 2023').getTime()
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '03 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'date',
+                arrange: 'desc',
+                fieldData: new Date('03 Jan 2023').getTime()
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '31 Oct 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'date',
+                arrange: 'desc',
+                fieldData: new Date('31 Oct 2023').getTime()
+              }
+            }
+          ]
+        }
+      ];
+
+      test('THEN the sidebar nodes are ordered correctly', () => {
+        const sorted = sortSidebarData(data);
+
+        expect(sorted[0].childNodes[0].name).toEqual('31 Oct 2023 Newsletter');
+        expect(sorted[0].childNodes[1].name).toEqual('05 May 2023 Newsletter');
+        expect(sorted[0].childNodes[2].name).toEqual('03 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[3].name).toEqual('01 Jan 2023 Newsletter');
+      });
+    });
+
+    describe('AND WHEN sorting by a date in ascending order', () => {
+      const data: SidebarDataNode[] = [
+        {
+          id: 'index',
+          fullPath: 'fullPath',
+          name: 'index page',
+          priority: undefined,
+          data: { level: 3, link: '/index' },
+          childNodes: [
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '01 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'date',
+                arrange: 'asc',
+                fieldData: new Date('01 Jan 2023').getTime()
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '05 May 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'date',
+                arrange: 'asc',
+                fieldData: new Date('05 May 2023').getTime()
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '03 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'date',
+                arrange: 'asc',
+                fieldData: new Date('03 Jan 2023').getTime()
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '31 Oct 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'date',
+                arrange: 'asc',
+                fieldData: new Date('31 Oct 2023').getTime()
+              }
+            }
+          ]
+        }
+      ];
+
+      test('THEN the sidebar nodes are ordered correctly', () => {
+        const sorted = sortSidebarData(data);
+
+        expect(sorted[0].childNodes[0].name).toEqual('01 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[1].name).toEqual('03 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[2].name).toEqual('05 May 2023 Newsletter');
+        expect(sorted[0].childNodes[3].name).toEqual('31 Oct 2023 Newsletter');
+      });
+    });
+
+    describe('AND WHEN sorting by a number in descending order', () => {
+      const data: SidebarDataNode[] = [
+        {
+          id: 'index',
+          fullPath: 'fullPath',
+          name: 'index page',
+          priority: undefined,
+          data: { level: 3, link: '/index' },
+          childNodes: [
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '01 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'number',
+                arrange: 'desc',
+                fieldData: 1
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '05 May 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'number',
+                arrange: 'desc',
+                fieldData: 3
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '03 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'number',
+                arrange: 'desc',
+                fieldData: 2
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '31 Oct 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'number',
+                arrange: 'desc',
+                fieldData: 4
+              }
+            }
+          ]
+        }
+      ];
+
+      test('THEN the sidebar nodes are ordered correctly', () => {
+        const sorted = sortSidebarData(data);
+
+        expect(sorted[0].childNodes[0].name).toEqual('31 Oct 2023 Newsletter');
+        expect(sorted[0].childNodes[1].name).toEqual('05 May 2023 Newsletter');
+        expect(sorted[0].childNodes[2].name).toEqual('03 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[3].name).toEqual('01 Jan 2023 Newsletter');
+      });
+    });
+
+    describe('AND WHEN sorting by a number in ascending order', () => {
+      const data: SidebarDataNode[] = [
+        {
+          id: 'index',
+          fullPath: 'fullPath',
+          name: 'index page',
+          priority: undefined,
+          data: { level: 3, link: '/index' },
+          childNodes: [
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '01 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'number',
+                arrange: 'asc',
+                fieldData: 1
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '05 May 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'number',
+                arrange: 'asc',
+                fieldData: 3
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '03 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'number',
+                arrange: 'asc',
+                fieldData: 2
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '31 Oct 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'number',
+                arrange: 'asc',
+                fieldData: 4
+              }
+            }
+          ]
+        }
+      ];
+
+      test('THEN the sidebar nodes are ordered correctly', () => {
+        const sorted = sortSidebarData(data);
+
+        expect(sorted[0].childNodes[0].name).toEqual('01 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[1].name).toEqual('03 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[2].name).toEqual('05 May 2023 Newsletter');
+        expect(sorted[0].childNodes[3].name).toEqual('31 Oct 2023 Newsletter');
+      });
+    });
+
+    describe('AND WHEN sorting by a string in descending order', () => {
+      const data: SidebarDataNode[] = [
+        {
+          id: 'index',
+          fullPath: 'fullPath',
+          name: 'index page',
+          priority: undefined,
+          data: { level: 3, link: '/index' },
+          childNodes: [
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '01 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'desc',
+                fieldData: 'a'
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '05 May 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'desc',
+                fieldData: 'm'
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '03 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'desc',
+                fieldData: 'd'
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '31 Oct 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'desc',
+                fieldData: 'y'
+              }
+            }
+          ]
+        }
+      ];
+
+      test('THEN the sidebar nodes are ordered correctly', () => {
+        const sorted = sortSidebarData(data);
+
+        expect(sorted[0].childNodes[0].name).toEqual('31 Oct 2023 Newsletter');
+        expect(sorted[0].childNodes[1].name).toEqual('05 May 2023 Newsletter');
+        expect(sorted[0].childNodes[2].name).toEqual('03 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[3].name).toEqual('01 Jan 2023 Newsletter');
+      });
+    });
+
+    describe('AND WHEN sorting by a string in ascending order', () => {
+      const data: SidebarDataNode[] = [
+        {
+          id: 'index',
+          fullPath: 'fullPath',
+          name: 'index page',
+          priority: undefined,
+          data: { level: 3, link: '/index' },
+          childNodes: [
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '01 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'asc',
+                fieldData: 'a'
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '05 May 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'asc',
+                fieldData: 'm'
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '03 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'asc',
+                fieldData: 'd'
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '31 Oct 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'asc',
+                fieldData: 'y'
+              }
+            }
+          ]
+        }
+      ];
+
+      test('THEN the sidebar nodes are ordered correctly', () => {
+        const sorted = sortSidebarData(data);
+
+        expect(sorted[0].childNodes[0].name).toEqual('01 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[1].name).toEqual('03 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[2].name).toEqual('05 May 2023 Newsletter');
+        expect(sorted[0].childNodes[3].name).toEqual('31 Oct 2023 Newsletter');
+      });
+    });
+
+    describe('AND WHEN sorting, priority trumps shared sort config', () => {
+      const data: SidebarDataNode[] = [
+        {
+          id: 'index',
+          fullPath: 'fullPath',
+          name: 'index page',
+          priority: undefined,
+          data: { level: 3, link: '/index' },
+          childNodes: [
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '01 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'asc',
+                fieldData: 'a'
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '05 May 2023 Newsletter',
+              priority: 10,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'asc',
+                fieldData: 'm'
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '03 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'asc',
+                fieldData: 'd'
+              }
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '31 Oct 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: [],
+              sharedSortConfig: {
+                field: 'field',
+                dataType: 'string',
+                arrange: 'asc',
+                fieldData: 'y'
+              }
+            }
+          ]
+        }
+      ];
+
+      test('THEN the sidebar nodes are ordered correctly', () => {
+        const sorted = sortSidebarData(data);
+
+        expect(sorted[0].childNodes[0].name).toEqual('05 May 2023 Newsletter');
+        expect(sorted[0].childNodes[1].name).toEqual('01 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[2].name).toEqual('03 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[3].name).toEqual('31 Oct 2023 Newsletter');
+      });
+    });
+  });
+
+  describe('AND WHEN there is **NO** shared sort config', () => {
+    describe('WHEN sorted', () => {
+      const data: SidebarDataNode[] = [
+        {
+          id: 'index',
+          fullPath: 'fullPath',
+          name: 'index page',
+          priority: undefined,
+          data: { level: 3, link: '/index' },
+          childNodes: [
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '01 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: []
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '05 May 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: []
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '03 Jan 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: []
+            },
+            {
+              id: 'id',
+              fullPath: 'fullPath',
+              name: '31 Oct 2023 Newsletter',
+              priority: undefined,
+              data: { level: 3, link: '/id' },
+              childNodes: []
+            }
+          ]
+        }
+      ];
+
+      test('THEN no sorting is applied', () => {
+        const sorted = sortSidebarData(data);
+
+        expect(sorted[0].childNodes[0].name).toEqual('01 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[1].name).toEqual('05 May 2023 Newsletter');
+        expect(sorted[0].childNodes[2].name).toEqual('03 Jan 2023 Newsletter');
+        expect(sorted[0].childNodes[3].name).toEqual('31 Oct 2023 Newsletter');
+      });
+    });
+  });
+});

--- a/packages/plugins/src/utils/sortSidebarData.ts
+++ b/packages/plugins/src/utils/sortSidebarData.ts
@@ -1,0 +1,71 @@
+type FieldData = string | number;
+type SortConfigDataType = 'string' | 'number' | 'date';
+
+export interface SortConfig {
+  field: string;
+  dataType: SortConfigDataType;
+  arrange: 'asc' | 'desc';
+}
+
+interface SortConfigWithValue extends SortConfig {
+  fieldData: FieldData;
+}
+
+export interface SidebarDataNode {
+  id: string;
+  fullPath: string;
+  name: string;
+  priority?: number;
+  data: { level: number; link: string };
+  childNodes: SidebarDataNode[];
+  sharedSortConfig?: SortConfigWithValue;
+}
+
+function doSort(dataType: SortConfigDataType, a: FieldData, b: FieldData) {
+  if (dataType === 'number' || dataType === 'date') {
+    return (a as number) - (b as number);
+  }
+  if (a > b) {
+    return 1;
+  }
+  if (a < b) {
+    return -1;
+  }
+  return 0;
+}
+
+function sortBySharedSortConfig(pageA: SidebarDataNode, pageB: SidebarDataNode) {
+  if (pageA.sharedSortConfig === undefined || pageB.sharedSortConfig === undefined) {
+    return 0;
+  }
+
+  if (pageA.sharedSortConfig?.arrange === 'asc') {
+    return doSort(
+      pageA.sharedSortConfig.dataType,
+      pageA.sharedSortConfig.fieldData,
+      pageB.sharedSortConfig.fieldData
+    );
+  }
+
+  return doSort(
+    pageB.sharedSortConfig.dataType,
+    pageB.sharedSortConfig.fieldData,
+    pageA.sharedSortConfig.fieldData
+  );
+}
+
+export function sortSidebarData(sidebarData: SidebarDataNode[]) {
+  const pagesByPriority = sidebarData.map(page => {
+    if (page.childNodes?.length > 1) {
+      const sortedChildNodes = page.childNodes.sort(
+        (pageA, pageB) =>
+          (pageB.priority ? pageB.priority : -1) - (pageA.priority ? pageA.priority : -1) ||
+          sortBySharedSortConfig(pageA, pageB)
+      );
+      sortSidebarData(page.childNodes);
+      return { ...page, childNodes: sortedChildNodes };
+    }
+    return page;
+  });
+  return pagesByPriority;
+}


### PR DESCRIPTION
Users have requested the ability to sort the sidebar using a particular field in page metadata e.g. publication date.

This PR allows a user to add a sidebar sort config to an index page. For example:

```
sharedConfig:
  sidebar:
    sort:
      field: data/publicationDate
      dataType: date
      arrange: desc
```

This sort config will be used to sort the pages in the *same directory* as the index page.

- `field` is the path the find the value you wish to sort by
- `dataType` is the type of the value.  it can be `string | number | Date`
- `arrange` is ascending (`asc`) or descending (`desc`)


## Note
the sidebar priority takes precedence over the shared sort config.