### PR TITLE
Generic http source

### DIFF
--- a/packages/source-http/src/__tests__/index.test.ts
+++ b/packages/source-http/src/__tests__/index.test.ts
@@ -1,9 +1,9 @@
-import { from, Observable, of, take } from 'rxjs';
+import { Observable, of, take } from 'rxjs';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 import type { Page } from '@jpmorganchase/mosaic-types';
 
-import Source from '../index.js';
+import Source, { createHttpSource } from '../index.js';
 import { fromDynamicImport } from '../fromDynamicImport.js';
 
 jest.mock('../fromDynamicImport', () => ({
@@ -170,6 +170,139 @@ describe('GIVEN an HTTP Source ', () => {
 
     it('no transformation of responses is carried out', done => {
       const source$: Observable<Page[]> = Source.create(
+        { ...options, transformResponseToPagesModulePath: undefined },
+        { schedule }
+      );
+
+      source$.pipe(take(1)).subscribe({
+        next: result => {
+          expect(result[0]).toEqual({ name: 'Alice' });
+          expect(result[1]).toEqual({ name: 'Bob' });
+          expect(result[2]).toEqual({ name: 'Eve' });
+        },
+        complete: () => done()
+      });
+    });
+  });
+});
+
+describe('GIVEN the createHttpSource function ', () => {
+  describe('WHEN a fetch is successful', () => {
+    const server = setupServer();
+    beforeAll(() => {
+      server.use(...successHandlers);
+      server.listen({ onUnhandledRequest: 'warn' });
+    });
+    afterAll(() => {
+      server.close();
+    });
+
+    it('should merge results from all endpoints into 1 array', done => {
+      const source$: Observable<Page[]> = createHttpSource(options, { schedule });
+
+      source$.pipe(take(1)).subscribe({
+        next: result => {
+          expect(result.length).toEqual(3);
+        },
+        complete: () => done()
+      });
+    });
+
+    it('should transform the responses using the transform function', done => {
+      const source$: Observable<Page[]> = createHttpSource(options, { schedule });
+
+      source$.pipe(take(1)).subscribe({
+        next: result => {
+          expect(result[0]).toEqual('ALICE');
+          expect(result[1]).toEqual('BOB');
+          expect(result[2]).toEqual('EVE');
+        },
+        complete: () => done()
+      });
+    });
+  });
+
+  describe('WHEN a fetch is **NOT** successful', () => {
+    const server = setupServer();
+    beforeAll(() => {
+      server.use(
+        rest.get(options.endpoints[0], (_req, res, ctx) => {
+          return res(ctx.status(200), ctx.json({ name: 'Alice' }));
+        }),
+        rest.get(options.endpoints[1], (_req, res, ctx) => {
+          return res(ctx.status(404));
+        }),
+        rest.get(options.endpoints[2], (_req, res, ctx) => {
+          return res(ctx.status(500));
+        })
+      );
+      server.listen({ onUnhandledRequest: 'warn' });
+    });
+    afterAll(() => {
+      server.close();
+    });
+
+    it('should merge results from **successful** endpoints into 1 array', done => {
+      const source$: Observable<Page[]> = createHttpSource(options, { schedule });
+
+      source$.pipe(take(1)).subscribe({
+        next: result => {
+          expect(result.length).toEqual(1);
+          expect(result[0]).toEqual('ALICE');
+        },
+        complete: () => done()
+      });
+    });
+  });
+
+  describe('WHEN the transformer has a request config', () => {
+    const server = setupServer();
+    beforeAll(() => {
+      server.use(...successHandlers);
+      server.listen({ onUnhandledRequest: 'warn' });
+    });
+    afterAll(() => {
+      server.close();
+    });
+    it('should merge results from **successful** endpoints into 1 array', done => {
+      const source$: Observable<Page[]> = createHttpSource(options, { schedule });
+
+      source$.pipe(take(1)).subscribe({
+        next: result => {
+          expect(result.length).toEqual(3);
+          expect(result[0]).toEqual('ALICE');
+        },
+        complete: () => done()
+      });
+    });
+  });
+
+  describe('WHEN no transformResponseToPagesModulePath is undefined', () => {
+    const server = setupServer();
+    beforeAll(() => {
+      server.use(...successHandlers);
+      server.listen({ onUnhandledRequest: 'warn' });
+    });
+    afterAll(() => {
+      server.close();
+    });
+
+    it('should merge results from all endpoints into 1 array', done => {
+      const source$: Observable<Page[]> = createHttpSource(
+        { ...options, transformResponseToPagesModulePath: undefined },
+        { schedule }
+      );
+
+      source$.pipe(take(1)).subscribe({
+        next: result => {
+          expect(result.length).toEqual(3);
+        },
+        complete: () => done()
+      });
+    });
+
+    it('no transformation of responses is carried out', done => {
+      const source$: Observable<Page[]> = createHttpSource(
         { ...options, transformResponseToPagesModulePath: undefined },
         { schedule }
       );

--- a/packages/source-http/src/fromDynamicImport.ts
+++ b/packages/source-http/src/fromDynamicImport.ts
@@ -1,4 +1,3 @@
-import type { Page } from '@jpmorganchase/mosaic-types';
 import { distinctUntilChanged, from, iif, of, switchMap } from 'rxjs';
 
 export type ResponseTransformer<TResponse, TOptions> = (
@@ -6,7 +5,7 @@ export type ResponseTransformer<TResponse, TOptions> = (
   prefixDir: string,
   index: number,
   options?: TOptions
-) => Page[];
+) => Array<TResponse>;
 
 async function importTransformer<T, O>(
   modulePath: string

--- a/packages/source-storybook/src/transformer.ts
+++ b/packages/source-storybook/src/transformer.ts
@@ -20,7 +20,7 @@ const createStorybookPages = (
     if (filter && !filter.test(story.kind)) {
       return result;
     }
-    if (filterTags && !filterTags.some(filterTag => story.tags.indexOf(filterTag) >= 0)) {
+    if (filterTags && filterTags.some(filterTag => story.tags.indexOf(filterTag) >= 0)) {
       return result;
     }
     const { id, kind, name, tags, story: storyName } = story;

--- a/packages/types/src/Source.ts
+++ b/packages/types/src/Source.ts
@@ -4,13 +4,24 @@ import type { Serialiser } from './Serialiser.js';
 import type { Page } from './Page.js';
 import { SourceSchedule } from './index.js';
 
-export type Source<Options = {}> = {
-  create(
-    options: Options,
-    {
-      serialiser,
-      pageExtensions,
-      schedule
-    }: { pageExtensions: string[]; serialiser: Serialiser; schedule: SourceSchedule }
-  ): Observable<Page[]>;
+/**
+ * Provided by Mosaic to a Source
+ */
+export type SourceConfig = {
+  /**
+   * The allowed page extensions Mosaic has been configured to use
+   */
+  pageExtensions: string[];
+  /**
+   * The page serialiser compatible with the pageExtensions
+   */
+  serialiser: Serialiser;
+  /**
+   * Scheduling configuration for the source
+   */
+  schedule: SourceSchedule;
+};
+
+export type Source<TOptions = Record<string, unknown>, TPage extends Page = Page> = {
+  create(options: TOptions, helpers: SourceConfig): Observable<TPage[]>;
 };


### PR DESCRIPTION
Now that the transformer is optional in the http source, it is possible for this source to return something other than a `Page[]`.


This PR exposes a generic `createHTTPSource` function that allows users to specify the response type