### PR TITLE
Storybook source proxy

### DIFF
--- a/.changeset/quiet-walls-lay.md
+++ b/.changeset/quiet-walls-lay.md
@@ -1,0 +1,20 @@
+---
+'@jpmorganchase/mosaic-source-http': patch
+'@jpmorganchase/mosaic-source-storybook': patch
+---
+
+## HTTP Source `noProxy` option
+
+The `noProxy` option is a regex used to check if an endpoint in the `endpoints` collection should create an http proxy agent for the request.
+
+## `createHttpSource` `configuredRequests` option
+
+When an http source is created using the `createHttpSource` function, instead of supplying a collection of endpoints, a `configuredRequests` option can be used to provide a collection of [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) objects.
+
+This gives full control over the request configuration to the user.
+
+_Should both `endpoints` and `configuredRequests` be provided then endpoints will take precedence._
+
+## Storybook Source
+
+Storybook config in the `stories` option can now specify a `proxyEndpoint`.

--- a/packages/source-http/src/proxyAgent.ts
+++ b/packages/source-http/src/proxyAgent.ts
@@ -1,0 +1,7 @@
+import proxyAgentPkg from 'https-proxy-agent';
+
+const { HttpsProxyAgent } = proxyAgentPkg;
+
+export function createProxyAgent(proxyUrl: string) {
+  return new HttpsProxyAgent(proxyUrl);
+}

--- a/packages/source-storybook/package.json
+++ b/packages/source-storybook/package.json
@@ -34,7 +34,6 @@
     "@jpmorganchase/mosaic-source-http": "^0.1.0-beta.57",
     "@jpmorganchase/mosaic-schemas": "^0.1.0-beta.57",
     "@jpmorganchase/mosaic-types": "^0.1.0-beta.57",
-    "https-proxy-agent": "^5.0.1",
     "rxjs": "^7.5.5",
     "zod": "^3.22.3"
   },


### PR DESCRIPTION
1. Adds a `noProxy` regex to http source. 
2. `createHttpSource` also accepts `configuredRequests` which allows users full control of the Request instance.  When provided, endpoints should not be used.  Endpoints will take precedence over `configuredRequests`
