### PR TITLE
refactor: rework how http source uses the transformer

### DIFF
--- a/packages/source-http/src/__tests__/index.test.ts
+++ b/packages/source-http/src/__tests__/index.test.ts
@@ -142,47 +142,6 @@ describe('GIVEN an HTTP Source ', () => {
     });
   });
 
-  describe('WHEN no transformResponseToPagesModulePath is undefined', () => {
-    const server = setupServer();
-    beforeAll(() => {
-      server.use(...successHandlers);
-      server.listen({ onUnhandledRequest: 'warn' });
-    });
-    afterAll(() => {
-      server.close();
-    });
-
-    it('should merge results from all endpoints into 1 array', done => {
-      const source$: Observable<Page[]> = Source.create(
-        { ...options, transformResponseToPagesModulePath: undefined },
-        { schedule }
-      );
-
-      source$.pipe(take(1)).subscribe({
-        next: result => {
-          expect(result.length).toEqual(3);
-        },
-        complete: () => done()
-      });
-    });
-
-    it('no transformation of responses is carried out', done => {
-      const source$: Observable<Page[]> = Source.create(
-        { ...options, transformResponseToPagesModulePath: undefined },
-        { schedule }
-      );
-
-      source$.pipe(take(1)).subscribe({
-        next: result => {
-          expect(result[0]).toEqual({ name: 'Alice' });
-          expect(result[1]).toEqual({ name: 'Bob' });
-          expect(result[2]).toEqual({ name: 'Eve' });
-        },
-        complete: () => done()
-      });
-    });
-  });
-
   describe('WHEN noProxy option is used', () => {
     const server = setupServer();
     beforeAll(() => {
@@ -226,7 +185,10 @@ describe('GIVEN the createHttpSource function ', () => {
     });
 
     it('should merge results from all endpoints into 1 array', done => {
-      const source$: Observable<Page[]> = createHttpSource(options, { schedule });
+      const source$: Observable<Page[]> = createHttpSource(
+        { ...options, transformer: toUpperCaseTransformer },
+        { schedule }
+      );
 
       source$.pipe(take(1)).subscribe({
         next: result => {
@@ -237,7 +199,10 @@ describe('GIVEN the createHttpSource function ', () => {
     });
 
     it('should transform the responses using the transform function', done => {
-      const source$: Observable<Page[]> = createHttpSource(options, { schedule });
+      const source$: Observable<Page[]> = createHttpSource(
+        { ...options, transformer: toUpperCaseTransformer },
+        { schedule }
+      );
 
       source$.pipe(take(1)).subscribe({
         next: result => {
@@ -271,7 +236,10 @@ describe('GIVEN the createHttpSource function ', () => {
     });
 
     it('should merge results from **successful** endpoints into 1 array', done => {
-      const source$: Observable<Page[]> = createHttpSource(options, { schedule });
+      const source$: Observable<Page[]> = createHttpSource(
+        { ...options, transformer: toUpperCaseTransformer },
+        { schedule }
+      );
 
       source$.pipe(take(1)).subscribe({
         next: result => {
@@ -283,30 +251,9 @@ describe('GIVEN the createHttpSource function ', () => {
     });
   });
 
-  describe('WHEN the transformer has a request config', () => {
+  describe('WHEN the transformer is passed params', () => {
     const server = setupServer();
-    beforeAll(() => {
-      server.use(...successHandlers);
-      server.listen({ onUnhandledRequest: 'warn' });
-    });
-    afterAll(() => {
-      server.close();
-    });
-    it('should merge results from **successful** endpoints into 1 array', done => {
-      const source$: Observable<Page[]> = createHttpSource(options, { schedule });
-
-      source$.pipe(take(1)).subscribe({
-        next: result => {
-          expect(result.length).toEqual(3);
-          expect(result[0]).toEqual('ALICE');
-        },
-        complete: () => done()
-      });
-    });
-  });
-
-  describe('WHEN no transformResponseToPagesModulePath is undefined', () => {
-    const server = setupServer();
+    const mockTransformer = jest.fn();
     beforeAll(() => {
       server.use(...successHandlers);
       server.listen({ onUnhandledRequest: 'warn' });
@@ -315,31 +262,19 @@ describe('GIVEN the createHttpSource function ', () => {
       server.close();
     });
 
-    it('should merge results from all endpoints into 1 array', done => {
+    it('should pass transformer options to the transformer', done => {
       const source$: Observable<Page[]> = createHttpSource(
-        { ...options, transformResponseToPagesModulePath: undefined },
+        { ...options, transformer: mockTransformer, transformerOptions: { option: 'an option' } },
         { schedule }
       );
 
       source$.pipe(take(1)).subscribe({
         next: result => {
-          expect(result.length).toEqual(3);
-        },
-        complete: () => done()
-      });
-    });
-
-    it('no transformation of responses is carried out', done => {
-      const source$: Observable<Page[]> = createHttpSource(
-        { ...options, transformResponseToPagesModulePath: undefined },
-        { schedule }
-      );
-
-      source$.pipe(take(1)).subscribe({
-        next: result => {
-          expect(result[0]).toEqual({ name: 'Alice' });
-          expect(result[1]).toEqual({ name: 'Bob' });
-          expect(result[2]).toEqual({ name: 'Eve' });
+          expect(mockTransformer).toBeCalledTimes(3);
+          expect(mockTransformer.mock.calls[0][0]).toEqual({ name: 'Alice' });
+          expect(mockTransformer.mock.calls[0][1]).toEqual(options.prefixDir);
+          expect(mockTransformer.mock.calls[0][2]).toEqual(0);
+          expect(mockTransformer.mock.calls[0][3]).toEqual({ option: 'an option' });
         },
         complete: () => done()
       });
@@ -361,9 +296,12 @@ describe('GIVEN the createHttpSource function ', () => {
     });
 
     it('should merge results from all endpoints into 1 array', done => {
-      const source$: Observable<Page[]> = createHttpSource(configuredRequestsOptions, {
-        schedule
-      });
+      const source$: Observable<Page[]> = createHttpSource(
+        { ...configuredRequestsOptions, transformer: toUpperCaseTransformer },
+        {
+          schedule
+        }
+      );
 
       source$.pipe(take(1)).subscribe({
         next: result => {
@@ -374,9 +312,12 @@ describe('GIVEN the createHttpSource function ', () => {
     });
 
     it('should transform the responses using the transform function', done => {
-      const source$: Observable<Page[]> = createHttpSource(configuredRequestsOptions, {
-        schedule
-      });
+      const source$: Observable<Page[]> = createHttpSource(
+        { ...configuredRequestsOptions, transformer: toUpperCaseTransformer },
+        {
+          schedule
+        }
+      );
 
       source$.pipe(take(1)).subscribe({
         next: result => {

--- a/packages/source-http/src/createHttpSource.ts
+++ b/packages/source-http/src/createHttpSource.ts
@@ -1,0 +1,99 @@
+import { forkJoin, timer } from 'rxjs';
+import { switchMap, map } from 'rxjs/operators';
+import { z } from 'zod';
+import type { Page, SourceConfig } from '@jpmorganchase/mosaic-types';
+import { fromHttpRequest, isErrorResponse } from '@jpmorganchase/mosaic-from-http-request';
+import { sourceScheduleSchema, validateMosaicSchema } from '@jpmorganchase/mosaic-schemas';
+
+import { createProxyAgent } from './proxyAgent.js';
+import { ResponseTransformer } from './fromDynamicImport.js';
+
+export { createProxyAgent };
+
+export type HttpSourceResponseTransformerType<TResponse, TPage> = ResponseTransformer<
+  TResponse,
+  TPage
+>;
+
+export const httpSourceCreatorSchema = z.object({
+  schedule: sourceScheduleSchema.optional(),
+  endpoints: z.array(z.string().url()).optional().default([]),
+  prefixDir: z.string({ required_error: 'Please provide a prefixDir' }),
+  requestTimeout: z.number().optional().default(5000),
+  proxyEndpoint: z.string().url().optional(),
+  noProxy: z
+    .any()
+    .transform(val => new RegExp(val))
+    .optional(),
+  requestHeaders: z.object({}).passthrough().optional(),
+  transformerOptions: z.unknown().optional()
+});
+
+export interface CreateHttpSourceParams<TResponse, TPage>
+  extends z.input<typeof httpSourceCreatorSchema> {
+  configuredRequests?: Request[];
+  transformer: HttpSourceResponseTransformerType<TResponse, TPage>;
+}
+
+/**
+ * For use inside *other* sources.
+ * Allows a transformer function to be passed directly without the need for dynamic imports.
+ *
+ */
+export function createHttpSource<TResponse, TPage extends Page>(
+  { configuredRequests, transformer, ...restOptions }: CreateHttpSourceParams<TResponse, TPage>,
+  { schedule }: SourceConfig
+) {
+  const {
+    endpoints,
+    prefixDir,
+    proxyEndpoint,
+    noProxy,
+    requestHeaders,
+    requestTimeout,
+    transformerOptions
+  } = validateMosaicSchema(httpSourceCreatorSchema, restOptions);
+
+  const delayMs = schedule.checkIntervalMins * 60000;
+  let requests = configuredRequests || [];
+
+  if (endpoints.length > 0) {
+    requests = endpoints.map(endpoint => {
+      let agent;
+      const headers = requestHeaders
+        ? (requestHeaders as HeadersInit)
+        : {
+            'Content-Type': 'application/json'
+          };
+
+      if (!noProxy?.test(endpoint) && proxyEndpoint) {
+        agent = createProxyAgent(proxyEndpoint);
+      }
+
+      return new Request(new URL(endpoint), {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        agent,
+        headers,
+        timeout: requestTimeout
+      });
+    });
+  }
+
+  return timer(schedule.initialDelayMs, delayMs).pipe(
+    switchMap(() => {
+      const fetches = requests.map((request, index) =>
+        fromHttpRequest<TResponse>(request).pipe(
+          map(response => {
+            if (isErrorResponse<TResponse>(response)) {
+              return [];
+            }
+
+            return transformer(response, prefixDir, index, transformerOptions);
+          })
+        )
+      );
+      return forkJoin(fetches).pipe(map(result => result.flat()));
+    })
+  );
+}

--- a/packages/source-http/src/index.ts
+++ b/packages/source-http/src/index.ts
@@ -1,122 +1,43 @@
-import { forkJoin, timer } from 'rxjs';
-import { switchMap, map } from 'rxjs/operators';
+import { switchMap } from 'rxjs/operators';
 import { z } from 'zod';
-import type { Page, Source, SourceConfig } from '@jpmorganchase/mosaic-types';
-import { fromHttpRequest, isErrorResponse } from '@jpmorganchase/mosaic-from-http-request';
-import { sourceScheduleSchema, validateMosaicSchema } from '@jpmorganchase/mosaic-schemas';
+import type { Page, Source } from '@jpmorganchase/mosaic-types';
+import { validateMosaicSchema } from '@jpmorganchase/mosaic-schemas';
 
 import { createProxyAgent } from './proxyAgent.js';
-import { fromDynamicImport, ResponseTransformer } from './fromDynamicImport.js';
+import { fromDynamicImport } from './fromDynamicImport.js';
+import {
+  createHttpSource,
+  type HttpSourceResponseTransformerType,
+  httpSourceCreatorSchema
+} from './createHttpSource.js';
 
-export { createProxyAgent };
+export {
+  createProxyAgent,
+  createHttpSource,
+  HttpSourceResponseTransformerType,
+  httpSourceCreatorSchema
+};
 
-export const schema = z.object({
-  schedule: sourceScheduleSchema.optional(),
-  endpoints: z.array(z.string().url()).optional().default([]),
-  prefixDir: z.string({ required_error: 'Please provide a prefixDir' }),
-  requestTimeout: z.number().optional().default(5000),
-  proxyEndpoint: z.string().url().optional(),
-  noProxy: z
-    .any()
-    .transform(val => new RegExp(val))
-    .optional(),
-  requestHeaders: z.object({}).passthrough().optional(),
-  transformResponseToPagesModulePath: z
-    .string({
+export const schema = httpSourceCreatorSchema.merge(
+  z.object({
+    transformResponseToPagesModulePath: z.string({
       description: `The path to a module that exports a function to transform request responses into Pages. The transformer must be a default export.
       If omitted, the raw request responses are returned unmodified`
     })
-    .optional(),
-  transformerOptions: z.unknown().optional()
-});
+  })
+);
 
 export type HttpSourceOptions = z.input<typeof schema>;
-export type HttpSourceResponseTransformerType<TResponse, TOptions> = ResponseTransformer<
-  TResponse,
-  TOptions
->;
-
-export interface CreateHttpSourceParams extends z.input<typeof schema> {
-  configuredRequests?: Request[];
-}
-
-/**
- * For use inside *other* sources.
- * Allows the return type to be defined
- */
-export function createHttpSource<TResponse>(
-  { configuredRequests, ...restOptions }: CreateHttpSourceParams,
-  { schedule }: SourceConfig
-) {
-  const {
-    endpoints,
-    prefixDir,
-    transformResponseToPagesModulePath,
-    transformerOptions,
-    proxyEndpoint,
-    noProxy,
-    requestHeaders,
-    requestTimeout
-  } = validateMosaicSchema(schema, restOptions);
-  const delayMs = schedule.checkIntervalMins * 60000;
-  const applyTransformer = transformResponseToPagesModulePath !== undefined;
-  let requests = configuredRequests || [];
-
-  if (endpoints.length > 0) {
-    requests = endpoints.map(endpoint => {
-      let agent;
-      const headers = requestHeaders
-        ? (requestHeaders as HeadersInit)
-        : {
-            'Content-Type': 'application/json'
-          };
-
-      if (!noProxy?.test(endpoint) && proxyEndpoint) {
-        agent = createProxyAgent(proxyEndpoint);
-      }
-
-      return new Request(new URL(endpoint), {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        agent,
-        headers,
-        timeout: requestTimeout
-      });
-    });
-  }
-
-  return fromDynamicImport<TResponse, typeof transformerOptions>(
-    transformResponseToPagesModulePath
-  ).pipe(
-    switchMap(({ transformer }) =>
-      timer(schedule.initialDelayMs, delayMs).pipe(
-        switchMap(() => {
-          const fetches = requests.map((request, index) =>
-            fromHttpRequest<TResponse>(request).pipe(
-              map(response => {
-                if (isErrorResponse<TResponse>(response)) {
-                  return [];
-                }
-
-                const result =
-                  applyTransformer && transformer !== null
-                    ? transformer(response, prefixDir, index, transformerOptions)
-                    : response;
-
-                return result;
-              })
-            )
-          );
-          return forkJoin(fetches).pipe(map(result => result.flat()));
-        })
-      )
-    )
-  );
-}
 
 const HttpSource: Source<HttpSourceOptions> = {
   create(options, sourceConfig) {
-    return createHttpSource<Page>(options, sourceConfig);
+    const { transformResponseToPagesModulePath } = validateMosaicSchema(schema, options);
+
+    return fromDynamicImport<Page>(transformResponseToPagesModulePath).pipe(
+      switchMap(({ transformer }) =>
+        createHttpSource<Page, Page>({ ...options, transformer }, sourceConfig)
+      )
+    );
   }
 };
 


### PR DESCRIPTION
The original http source implementation needed to dynamically import the transformer function because source options must be serialisable as they are eventually passed to a source worker thread.

When the `createHttpSource` function was recently introduced we sort of made the transformer optional and that responses would be transformed later.  This was probably the wrong approach for the following reasons:

1. Sources should **always** return pages.  By allowing the `createHttpSource` function to return raw responses that are transformed into pages later we break this contract.
2. A failed http request returns an empty array which then is flattened.  The result is that come transformation time the index passed to the transform function can be out of sync with the response collection.  Not good for transforms.

This change makes the `transformer` required again but you can pass it directly to the `createHttpSource` function.