### PR TITLE
Fix routing breaking when URL parameters are present

### DIFF
--- a/.changeset/calm-pants-cheat.md
+++ b/.changeset/calm-pants-cheat.md
@@ -1,0 +1,5 @@
+---
+'@jpmorganchase/mosaic-site-middleware': patch
+---
+
+Fixed routing breaking when URL parameters are present.

--- a/packages/site-middleware/src/withMDXContent.ts
+++ b/packages/site-middleware/src/withMDXContent.ts
@@ -14,8 +14,15 @@ import { compileMDX } from './compileMdx.js';
 if (typeof window !== 'undefined') {
   throw new Error('This file should not be loaded on the client.');
 }
+function stripParams(resolvedUrl: string) {
+  const url = new URL(resolvedUrl, 'https://example.com');
+  return url.pathname;
+}
 
-const normalizeUrl = url => (/\/index$/.test(url) ? `${url}.mdx` : url);
+function normalizeUrl(url: string) {
+  const pathname = stripParams(url);
+  return /\/index$/.test(pathname) ? `${pathname}.mdx` : pathname;
+}
 
 async function loadSnapshotFile(url) {
   const { snapshotDir } = getSnapshotFileConfig(url);


### PR DESCRIPTION
https://mosaic-git-fix-routing-breaking-when-url-2aed10-mosaic-dev-team.vercel.app/mosaic/index?test=test will now work

where https://mosaic-git-main-mosaic-dev-team.vercel.app/mosaic/index?test=test fails