### PR TITLE
feat: add Figma source (UITK-10184)

### DIFF
--- a/docs/configure/sources/storybook-figma.mdx
+++ b/docs/configure/sources/storybook-figma.mdx
@@ -1,0 +1,80 @@
+---
+title: Figma Source
+layout: DetailTechnical
+sidebar:
+  priority: 5
+  label: Figma
+---
+
+# {meta.title}
+
+The Figma source is used to pull individual design patterns from Figma projects.
+The source subscribes to Figma project groups, then extracts from project files, tagged patterns.
+
+A Figma pattern tag is defined within a Figma project's `sharedPluginData`.
+(Refer to the JPM Figma plugin for more details - a current Q4 2023 deliverable)
+
+For each retrieved/tagged pattern, a page is created in the Mosaic file-system.
+Additional Mosaic medata can be added, to each created page, using `projects.meta`
+For instance we could add metadata which defines which product owns a particular pattern and then
+group patterns based on owner.
+
+## Installation
+
+`yarn add @jpmorganchase/mosaic-source-figma`
+
+## Configuration
+
+The Figma source is an [`HttpSource`](./https-source) and shares the same base configuration.
+The `transformResponseToPagesModulePath` prop has a default transformer which creates a page for each matching Story.
+
+| Property   | Description                       | Required |
+| ---------- | --------------------------------- | -------- |
+| prefixDir  | path to store figma patterns      | Yes      |
+| figmaToken | figma access token                | Yes      |
+| projects   | array of projects to subscribe to | Yes      |
+| endpoints  | figma endpoints                   | Yes      |
+
+Each project is configured from the `projects` array.
+
+| Property | Description                                   | Required |
+| -------- | --------------------------------------------- | -------- |
+| id       | numerical id of the subscribed project group  | Yes      |
+| meta     | metadata to add to each of the projects pages | Yes      |
+
+`endpoints` defined the Figma REST API endpoints.
+
+| Property   | Description                                               | Required |
+| ---------- | --------------------------------------------------------- | -------- |
+| getProject | url to return a list of projects within the project group | Yes      |
+| getFile    | url to return a project file                              | Yes      |
+
+### Example Local Folder Source Definition
+
+```
+sources: [
+    {
+      modulePath: '@jpmorganchase/mosaic-source-figma',
+      namespace: 'some-namespace',
+      options: {
+        requestHeaders: {
+          'Content-Type': 'application/json',
+          'X-FIGMA-TOKEN': process.env.FIGMA_TOKEN
+        },
+        proxyEndpoint: 'http://path/to/optional/proxy',
+        prefixDir: '/some/path/to/where/you/store/pattern/pages',
+        figmaToken: process.env.FIGMA_TOKEN,
+        projects: [{
+          id: 99999,
+          meta: {
+            owner: 'some-owner'
+          }
+        }],
+        endpoints: {
+          getFile: 'https://api.figma.com/v1/files/:file_id?plugin_data=shared',
+          getProject: 'https://api.figma.com/v1/projects/:project_id/files'
+        }
+      }
+    }
+]
+```

--- a/jest.config.server.js
+++ b/jest.config.server.js
@@ -21,6 +21,7 @@ module.exports = {
     '<rootDir>/packages/fromHttpRequest',
     '<rootDir>/packages/plugins',
     '<rootDir>/packages/site-middleware',
+    '<rootDir>/packages/source-figma',
     '<rootDir>/packages/source-http',
     '<rootDir>/packages/source-storybook'
   ],

--- a/packages/source-figma/package.json
+++ b/packages/source-figma/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@jpmorganchase/mosaic-source-figma",
+  "version": "0.1.0-beta.58",
+  "author": "",
+  "description": "Mosaic Figma source for core file system",
+  "license": "Apache-2.0",
+  "main": "./dist/index.js",
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "node": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "engines": {
+    "node": ">= 16.0.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -fr dist",
+    "lint": "eslint --ignore-pattern \"**/__tests__/**\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:jpmorganchase/mosaic.git"
+  },
+  "dependencies": {
+    "@jpmorganchase/mosaic-source-http": "^0.1.0-beta.58",
+    "@jpmorganchase/mosaic-schemas": "^0.1.0-beta.58",
+    "@jpmorganchase/mosaic-types": "^0.1.0-beta.58",
+    "deepmerge": "^4.2.2",
+    "rxjs": "^7.5.5",
+    "zod": "^3.22.3"
+  },
+  "devDependencies": {
+    "msw": "^0.47.4"
+  }
+}

--- a/packages/source-figma/src/__tests__/index.test.ts
+++ b/packages/source-figma/src/__tests__/index.test.ts
@@ -1,0 +1,148 @@
+import { Observable, take } from 'rxjs';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+import { FigmaPage } from '../types/index.js';
+
+import Source from '../index.js';
+
+const schedule = {
+  checkIntervalMins: 3,
+  initialDelayMs: 0
+};
+
+const options = {
+  requestTimeout: 1000,
+  prefixDir: '/prefixDir',
+  figmaToken: 'someFigmaToken',
+  projects: [
+    {
+      id: 888,
+      meta: {
+        layout: 'layout project 1',
+        data: { owner: 'owner project 1' },
+        tags: ['additional-tag-1']
+      }
+    },
+    {
+      id: 999,
+      meta: {
+        layout: 'layout project 2',
+        data: { owner: 'owner project 2' },
+        tags: ['additional-tag-2']
+      }
+    }
+  ],
+  endpoints: {
+    getProject: 'https://myfigma/:project_id/files',
+    getFile: 'https://myfigma/:file_id?plugin_data=shared'
+  }
+};
+
+const getProjectById = (id: number) =>
+  options.projects.find(item => item.id === id) || { meta: { tags: [] } };
+
+const createProjectsResponse = (patternId: string) => [
+  {
+    name: 'Figma Test Patterns',
+    files: [
+      {
+        key: patternId
+      }
+    ]
+  }
+];
+const createProjectFilesResponse = (patternId: string) => ({
+  document: {
+    sharedPluginData: {
+      [`jpmSaltPattern.${patternId}`]: {
+        description: `some description for ${patternId}`,
+        link: 'some link',
+        name: patternId,
+        node: 'X:Y',
+        embedLink: 'some embed link',
+        tags: 'some-tag1,some-tag2',
+        version: 'some version'
+      }
+    }
+  }
+});
+
+const createExpectedResult = (patternId: string, data: Record<string, any>) => ({
+  title: patternId,
+  description: `some description for ${patternId}`,
+  layout: 'DetailTechnical',
+  route: `/prefixdir/jpmsaltpattern_${patternId}`,
+  fullPath: `/prefixdir/jpmsaltpattern_${patternId}.mdx`,
+  tags: ['some-tag1', 'some-tag2'],
+  ...data,
+  data: {
+    description: `some description for ${patternId}`,
+    embedLink: 'some embed link',
+    link: 'some link',
+    node: 'X:Y',
+    name: patternId,
+    patternId: `jpmSaltPattern.${patternId}`,
+    source: 'FIGMA',
+    tags: 'some-tag1,some-tag2',
+    version: 'some version',
+    ...data.data
+  },
+  content: ''
+});
+
+const successHandlers = [
+  // Project 1 - pattern 1
+  rest.get(`${options.endpoints.getProject}`.replace(':project_id', '888'), (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(createProjectsResponse('pattern1')));
+  }),
+  rest.get(
+    `${options.endpoints.getFile.replace(':file_id', 'pattern1')}?plugin_data=shared`,
+    (_req, res, ctx) => {
+      return res(ctx.status(200), ctx.json(createProjectFilesResponse('pattern1')));
+    }
+  ),
+  // Project 2 - pattern 2
+  rest.get(`${options.endpoints.getProject}`.replace(':project_id', '999'), (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(createProjectsResponse('pattern2')));
+  }),
+  rest.get(
+    `${options.endpoints.getFile.replace(':file_id', 'pattern2')}?plugin_data=shared`,
+    (_req, res, ctx) => {
+      return res(ctx.status(200), ctx.json(createProjectFilesResponse('pattern2')));
+    }
+  )
+];
+//myfigma/pattern1?plugin_data=shared
+https: describe('GIVEN a Figma Source ', () => {
+  describe('WHEN a fetch is successful', () => {
+    const server = setupServer();
+    beforeAll(() => {
+      server.use(...successHandlers);
+      server.listen({ onUnhandledRequest: 'warn' });
+    });
+    afterAll(() => {
+      server.close();
+    });
+
+    it('should return the 2 patterns for the 2 subscribed projects', done => {
+      const source$: Observable<FigmaPage[]> = Source.create(options, { schedule });
+      source$.pipe(take(1)).subscribe({
+        next: result => {
+          expect(result[0]).toEqual(
+            createExpectedResult('pattern1', {
+              ...getProjectById(888).meta,
+              tags: ['some-tag1', 'some-tag2', ...getProjectById(888).meta.tags]
+            })
+          );
+          expect(result[1]).toEqual(
+            createExpectedResult('pattern2', {
+              ...getProjectById(999).meta,
+              tags: ['some-tag1', 'some-tag2', ...getProjectById(999).meta.tags]
+            })
+          );
+        },
+        complete: () => done()
+      });
+    });
+  });
+});

--- a/packages/source-figma/src/index.ts
+++ b/packages/source-figma/src/index.ts
@@ -1,0 +1,185 @@
+import { merge, mergeMap, map } from 'rxjs';
+import { z } from 'zod';
+import deepmerge from 'deepmerge';
+import type { Source } from '@jpmorganchase/mosaic-types';
+import { validateMosaicSchema } from '@jpmorganchase/mosaic-schemas';
+import {
+  createHttpSource,
+  createProxyAgent,
+  schema as httpSourceSchema
+} from '@jpmorganchase/mosaic-source-http';
+
+import createFigmaPage from './transformer.js';
+import { FigmaPage, ProjectFilesResponseJson, ProjectResponseJson } from './types/index.js';
+
+const JPM_PATTERN_PREFIX = 'jpmSaltPattern.';
+
+const baseSchema = httpSourceSchema.omit({
+  endpoints: true, // will be generated from the url in the stories object,
+  transformerOptions: true // stories is the prop we need for this so no point duplicating it in source config
+});
+
+const defaultRequestHeaders: HeadersInit = {
+  'Content-Type': 'application/json',
+  'X-FIGMA-TOKEN': process.env.FIGMA_TOKEN || ''
+};
+export const schema = baseSchema.merge(
+  z.object({
+    prefixDir: z.string(),
+    figmaToken: z.string(),
+    projects: z.array(
+      z.object({
+        id: z.number(),
+        meta: z.object({}).passthrough()
+      })
+    ),
+    endpoints: z.object({
+      getFile: z.string().url(),
+      getProject: z.string().url()
+    }),
+    requestTimeout: z.number().default(5000)
+  })
+);
+
+export type FigmaSourceOptions = z.infer<typeof schema>;
+
+type ProjectRequestAndOptions = { request: Request; meta: Partial<FigmaPage> };
+
+function createProjectRequestsAndOptions({
+  endpoints,
+  projects,
+  proxyEndpoint,
+  requestTimeout,
+  requestHeaders
+}: FigmaSourceOptions): { request: Request; meta: Partial<FigmaPage> }[] {
+  return projects.map<ProjectRequestAndOptions>(({ id, meta }) => {
+    let agent;
+    const getProjectURL = endpoints.getProject.replace(':project_id', id.toString());
+    const headers = requestHeaders ? (requestHeaders as HeadersInit) : defaultRequestHeaders;
+    if (proxyEndpoint) {
+      agent = createProxyAgent(proxyEndpoint);
+    }
+
+    const request = new Request(getProjectURL, {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      agent,
+      headers,
+      timeout: requestTimeout
+    });
+    return { request, meta };
+  });
+}
+
+function createProjectFileRequests(
+  projectFileUrls: string[],
+  { proxyEndpoint, requestHeaders, requestTimeout }: FigmaSourceOptions
+) {
+  return projectFileUrls.map(projectFileURL => {
+    let agent;
+    const headers = requestHeaders ? (requestHeaders as HeadersInit) : defaultRequestHeaders;
+    if (proxyEndpoint) {
+      agent = createProxyAgent(proxyEndpoint);
+    }
+    return new Request(projectFileURL, {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      agent,
+      headers,
+      timeout: requestTimeout
+    });
+  });
+}
+
+const FigmaSource: Source<FigmaSourceOptions, FigmaPage> = {
+  create(options, sourceConfig) {
+    const parsedOptions = validateMosaicSchema(schema, options);
+
+    const {
+      requestTimeout,
+      requestHeaders,
+      prefixDir,
+      proxyEndpoint,
+      projects,
+      endpoints,
+      ...restOptions
+    } = parsedOptions;
+
+    const requestsAndOptions = createProjectRequestsAndOptions(parsedOptions);
+    // Get a list of project file descriptors for each configured project group
+    const configuredRequests = requestsAndOptions.map(
+      requestAndOptions => requestAndOptions.request
+    );
+    const figmaProjectsHttpSource$ = createHttpSource<ProjectFilesResponseJson>(
+      {
+        prefixDir,
+        ...restOptions,
+        configuredRequests
+      },
+      sourceConfig
+    ).pipe(
+      map(projectsResponse => {
+        return projectsResponse.reduce<string[]>((allProjectFileUrls, { files }) => {
+          const projectFileUrls = files.reduce<string[]>((project, { key }) => {
+            const getProjectFileURL = endpoints.getFile.replace(':file_id', key);
+            return [...project, getProjectFileURL];
+          }, []);
+          return [...allProjectFileUrls, ...projectFileUrls];
+        }, []);
+      })
+    );
+
+    const figmaSource$ = figmaProjectsHttpSource$.pipe(
+      map(projectResponses => {
+        const configuredProjectFileRequests = createProjectFileRequests(
+          projectResponses,
+          parsedOptions
+        );
+        const figmaProjectFilesHttpSource$ = createHttpSource<ProjectResponseJson>(
+          {
+            prefixDir,
+            ...restOptions,
+            configuredRequests: configuredProjectFileRequests
+          },
+          sourceConfig
+        );
+        return figmaProjectFilesHttpSource$.pipe(
+          map(projectsResponse => {
+            return projectsResponse.reduce<FigmaPage[]>((projectFile, response, responseIndex) => {
+              const {
+                document: { sharedPluginData }
+              } = response;
+              const figmaPages = Object.keys(sharedPluginData).reduce<FigmaPage[]>(
+                (figmaPagesResult, patternId) => {
+                  if (patternId.indexOf(JPM_PATTERN_PREFIX) === 0) {
+                    /** Figma provided metadata */
+                    const figmaProvidedMetadata: Partial<FigmaPage> = {
+                      data: {
+                        patternId,
+                        ...sharedPluginData[patternId]
+                      }
+                    };
+                    const sourceProvidedMetadata = requestsAndOptions[responseIndex].meta;
+                    const figmaPageMeta = requestsAndOptions[responseIndex]
+                      ? deepmerge<FigmaPage, FigmaPage>(
+                          figmaProvidedMetadata,
+                          sourceProvidedMetadata
+                        )
+                      : figmaProvidedMetadata;
+                    return [...figmaPagesResult, createFigmaPage(figmaPageMeta, prefixDir)];
+                  }
+                  return figmaPagesResult;
+                },
+                []
+              );
+              return [...projectFile, ...figmaPages];
+            }, []);
+          })
+        );
+      })
+    );
+    return figmaSource$.pipe(mergeMap(res => merge(res)));
+  }
+};
+
+export default FigmaSource;

--- a/packages/source-figma/src/transformer.ts
+++ b/packages/source-figma/src/transformer.ts
@@ -1,0 +1,20 @@
+import { FigmaPage } from './types/index.js';
+import deepmerge from 'deepmerge';
+
+const createFigmaPage = (pageData: Partial<FigmaPage>, prefixDir: string) => {
+  const { data: { name, description, patternId, tags } = {} } = pageData;
+  const route = `${prefixDir}/${patternId}`.replace(/\./g, '_').toLowerCase();
+  const pageTags = tags ? tags.split(',') : [];
+  const figmaPage = {
+    title: name,
+    data: { source: 'FIGMA' },
+    description,
+    route,
+    fullPath: `${route}.json`,
+    tags: pageTags,
+    content: ``
+  };
+  return deepmerge<typeof figmaPage, FigmaPage>(figmaPage, pageData);
+};
+
+export default createFigmaPage;

--- a/packages/source-figma/src/types/index.ts
+++ b/packages/source-figma/src/types/index.ts
@@ -1,0 +1,46 @@
+import type { Page } from '@jpmorganchase/mosaic-types';
+
+/** Get project response */
+export type ProjectResponseJson = {
+  document: {
+    id: string;
+    name: string;
+    sharedPluginData: Record<string, any>;
+  };
+  name: string;
+  lastModified: string;
+  thumbnailUrl: string;
+  version: string;
+};
+
+export type ProjectFile = {
+  key: string;
+  thumbnail_url: string;
+  last_modified: string;
+  branches?: ProjectFile[];
+};
+
+/** Get project files response */
+export type ProjectFilesResponseJson = {
+  name: string;
+  files: ProjectFile[];
+};
+
+/** Figma page Metadata */
+export type FigmaPageData = {
+  name: string;
+  patternId: string;
+  description: string;
+  embedLink: string;
+  link: string;
+  source: 'FIGMA';
+  tags?: string;
+};
+
+/** Figma page */
+export type FigmaPage = {
+  content: string;
+  description?: string;
+  data: FigmaPageData;
+  tags: string[];
+} & Page;

--- a/packages/source-figma/tsconfig.json
+++ b/packages/source-figma/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/__tests__/**/*", "src/__tests__/**/*"]
+}


### PR DESCRIPTION
A Figma source pulls tagged patterns via Figma's REST API and stores them as JSON in the VFS.

We can build up dynamic pages which group/list Figma embeds from this metadata.