### PR TITLE
refactor: instantiate mosaic before registering fastify plugins

### DIFF
--- a/packages/cli/src/plugins/createMosaicInstance.ts
+++ b/packages/cli/src/plugins/createMosaicInstance.ts
@@ -1,0 +1,8 @@
+import { MosaicConfig } from '@jpmorganchase/mosaic-types';
+import MosaicCore from '@jpmorganchase/mosaic-core';
+
+export async function createMosaicInstance(config: MosaicConfig) {
+  const mosaic = new MosaicCore(config);
+  await mosaic.start();
+  return mosaic;
+}

--- a/packages/cli/src/plugins/mosaicFastifyPlugin.ts
+++ b/packages/cli/src/plugins/mosaicFastifyPlugin.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 export interface FastifyMosaicPluginOptions {
   config: MosaicConfig;
   scope?: string[];
+  mosaic: MosaicCore;
 }
 
 export interface FastifyMosaic {
@@ -16,9 +17,7 @@ export interface FastifyMosaic {
 }
 
 async function fastifyMosaic(fastify: FastifyInstance, options: FastifyMosaicPluginOptions) {
-  const { config, scope } = options;
-  const mosaic = new MosaicCore(config);
-  await mosaic.start();
+  const { config, scope, mosaic } = options;
   const fs = Array.isArray(scope) ? mosaic.filesystem.scope(scope) : mosaic.filesystem;
   fastify.decorate('mosaic', { config, core: mosaic, fs });
 

--- a/packages/cli/src/serve.ts
+++ b/packages/cli/src/serve.ts
@@ -6,6 +6,7 @@ import middie from '@fastify/middie';
 import fastifyMosaic from './plugins/mosaicFastifyPlugin.js';
 import fastifyMosaicAdmin from './plugins/mosaicAdminPlugin.js';
 import fastifyMosaicWorkflows from './plugins/mosaicWorkflowsPlugin.js';
+import { createMosaicInstance } from './plugins/createMosaicInstance.js';
 
 const MOSAIC_ADMIN_PREFIX = '_mosaic_';
 
@@ -15,8 +16,9 @@ export const server = Fastify({
 });
 
 export default async function serve(config: MosaicConfig, port: number, scope?: string[]) {
+  const mosaic = await createMosaicInstance(config);
   await server.register(middie);
-  await server.register(fastifyMosaic, { config, scope });
+  await server.register(fastifyMosaic, { config, scope, mosaic });
   await server.register(fastifyMosaicWorkflows);
   await server.register(fastifyMosaicAdmin, {
     prefix: MOSAIC_ADMIN_PREFIX,


### PR DESCRIPTION
Adding a large number of sources to mosaic increases the start time which can cause the `mosaicFastifyPlugin` to timeout.

Rather than disable or increase the timeout, this PR instantiates and starts mosaic *before* registering any fastify plugin(including mosaic ones).

This should prevent the timeout.