### PR TITLE
fix: exclude salt from sitemap component bundle

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -42,6 +42,8 @@
     "@jpmorganchase/mosaic-store": "^0.1.0-beta.64",
     "@jpmorganchase/mosaic-theme": "^0.1.0-beta.64",
     "@philpl/buble": "^0.19.7",
+    "@salt-ds/core": "^1.15.0",
+    "@salt-ds/lab": "1.0.0-alpha.28",
     "@types/react": "^18.0.26",
     "next": "^13.4.1",
     "next-auth": "^4.24.5"

--- a/packages/sitemap-component/package.json
+++ b/packages/sitemap-component/package.json
@@ -41,6 +41,8 @@
   },
   "dependencies": {
     "@jpmorganchase/mosaic-components": "^0.1.0-beta.64",
+    "@salt-ds/core": "^1.15.0",
+    "@salt-ds/lab": "1.0.0-alpha.28",
     "d3": "^7.7.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Salt was being included in the sitemap component bundle causing styling issues.  Adding salt to the package deps of the sitemap component means it will be excluded by the node externals esbuild plugin.