### PR TITLE
refactor: tactical fix to remove `react-pro-sidebar` and replace with…

### DIFF
--- a/.changeset/sour-geckos-add.md
+++ b/.changeset/sour-geckos-add.md
@@ -1,0 +1,9 @@
+---
+'@jpmorganchase/mosaic-components': patch
+'@jpmorganchase/mosaic-layouts': patch
+'@jpmorganchase/mosaic-plugins': patch
+'@jpmorganchase/mosaic-site-components': patch
+'@jpmorganchase/mosaic-site-middleware': patch
+---
+
+- Tactical fix to remove `react-pro-sidebar` and replace with Salt's `NavigationItem`. We will remove this local `NavigationItem` once Salt merges it's own PR.

--- a/packages/components/src/Link/index.tsx
+++ b/packages/components/src/Link/index.tsx
@@ -18,66 +18,67 @@ export interface LinkProps extends LinkBaseProps, Omit<LinkTextProps, 'variant'>
   variant?: 'component' | 'document' | 'heading' | 'regular' | 'selectable';
 }
 
-export const Link = forwardRef<HTMLLinkElement, LinkProps>((props, ref: Ref<HTMLLinkElement>) => {
-  const {
-    children,
-    className,
-    disabled,
-    endIcon,
-    hovered,
-    link,
-    href = link,
-    LinkBaseProps: LinkBasePropsProp,
-    LinkTextProps: LinkTextPropsProp,
-    onClick,
-    rel,
-    startIcon,
-    target,
-    title,
-    variant = 'regular',
-    ...rest
-  } = props;
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  (props, ref: Ref<HTMLAnchorElement>) => {
+    const {
+      children,
+      className,
+      disabled,
+      endIcon,
+      hovered,
+      link,
+      href = link,
+      LinkBaseProps: LinkBasePropsProp,
+      LinkTextProps: LinkTextPropsProp,
+      onClick,
+      rel,
+      startIcon,
+      target,
+      title,
+      variant = 'regular',
+      ...rest
+    } = props;
 
-  const linkTextProps = {
-    children,
-    disabled,
-    endIcon,
-    link,
-    hovered,
-    startIcon,
-    ...LinkTextPropsProp
-  };
-  return (
-    <LinkBase
-      disabled={disabled}
-      href={href}
-      onClick={onClick}
-      {...LinkBasePropsProp}
-      className={classnames(
-        styles.link,
-        {
-          [styles.inline]: variant === 'document',
-          [styles.document]: variant === 'document',
-          [styles.heading]: variant === 'heading',
-          [styles.regular]: variant === 'regular',
-          [styles.selectable]: variant === 'selectable'
-        },
-        LinkBasePropsProp?.className,
-        className
-      )}
-      ref={ref}
-      rel={rel}
-      target={target}
-      title={title}
-      {...rest}
-    >
-      {variant === 'regular' || variant === 'document' ? (
-        <LinkText variant={variant} {...linkTextProps}>
-          {children}
-        </LinkText>
-      ) : (
-        children
-      )}
-    </LinkBase>
-  );
-});
+    const linkTextProps = {
+      children,
+      disabled,
+      endIcon,
+      link,
+      hovered,
+      startIcon,
+      ...LinkTextPropsProp
+    };
+    return (
+      <LinkBase
+        disabled={disabled}
+        href={href}
+        onClick={onClick}
+        {...LinkBasePropsProp}
+        className={classnames(
+          {
+            [styles.inline]: variant === 'document',
+            [styles.document]: variant === 'document',
+            [styles.heading]: variant === 'heading',
+            [styles.regular]: variant === 'regular',
+            [styles.selectable]: variant === 'selectable'
+          },
+          LinkBasePropsProp?.className,
+          className
+        )}
+        ref={ref}
+        rel={rel}
+        target={target}
+        title={title}
+        {...rest}
+      >
+        {variant === 'regular' || variant === 'document' ? (
+          <LinkText variant={variant} {...linkTextProps}>
+            {children}
+          </LinkText>
+        ) : (
+          children
+        )}
+      </LinkBase>
+    );
+  }
+);

--- a/packages/components/src/Link/styles.css.ts
+++ b/packages/components/src/Link/styles.css.ts
@@ -2,9 +2,6 @@ import { link } from '@jpmorganchase/mosaic-theme';
 import { style } from '@vanilla-extract/css';
 
 export default {
-  link: style({
-    display: 'block'
-  }),
   inline: style({
     display: 'inline-block'
   }),

--- a/packages/components/src/LinkBase/index.tsx
+++ b/packages/components/src/LinkBase/index.tsx
@@ -3,15 +3,15 @@ import React, { forwardRef, Ref } from 'react';
 import { useLinkComponent } from '../LinkProvider';
 import { hasProtocol } from '../utils/hasProtocol';
 
-export interface LinkBaseProps extends Omit<React.HTMLProps<HTMLLinkElement>, 'ref'> {
+export interface LinkBaseProps extends Omit<React.HTMLProps<HTMLAnchorElement>, 'ref'> {
   /** Children */
   children?: React.ReactNode;
   /** Additional class name for root class override */
   className?: string;
 }
 
-export const LinkBase = forwardRef<HTMLLinkElement, LinkBaseProps>(
-  (props, ref: Ref<HTMLLinkElement>) => {
+export const LinkBase = forwardRef<HTMLAnchorElement, LinkBaseProps>(
+  (props, ref: Ref<HTMLAnchorElement>) => {
     const { children, href, ...rest } = props;
     const LinkComponent = useLinkComponent();
     const isInternal = !hasProtocol(href);

--- a/packages/layouts/src/LayoutBase/index.tsx
+++ b/packages/layouts/src/LayoutBase/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Spinner } from '@salt-ds/core';
 import classnames from 'clsx';
-import { SidebarProvider } from '@jpmorganchase/mosaic-site-components';
 
 import { useIsLoading } from '../hooks/useIsLoading';
 import { Fade } from '../Fade';
@@ -19,19 +18,17 @@ export const LayoutBase = ({
   // Add a delay before showing loading state, so loading screen doesn't appear if page loads quickly
   const isLoading = useIsLoading({ loadingDelay: 50 });
   return (
-    <SidebarProvider>
-      <div className={classnames(styles.root, className)}>
-        <header className={styles.header}>{Header}</header>
-        <main className={styles.main}>
-          <Fade style={{ transitionDelay: isLoading ? '1000ms' : '0ms' }} in={isLoading}>
-            <div className={styles.overlayRoot}>
-              <div className={styles.overlayInner} />
-              <Spinner size="large" />
-            </div>
-          </Fade>
-          <React.Fragment>{children}</React.Fragment>
-        </main>
-      </div>
-    </SidebarProvider>
+    <div className={classnames(styles.root, className)}>
+      <header className={styles.header}>{Header}</header>
+      <main className={styles.main}>
+        <Fade style={{ transitionDelay: isLoading ? '1000ms' : '0ms' }} in={isLoading}>
+          <div className={styles.overlayRoot}>
+            <div className={styles.overlayInner} />
+            <Spinner size="large" />
+          </div>
+        </Fade>
+        <React.Fragment>{children}</React.Fragment>
+      </main>
+    </div>
   );
 };

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -54,7 +54,6 @@
     "lodash-es": "^4.17.21",
     "memfs": "^3.4.12",
     "react-docgen-typescript": "^2.2.2",
-    "react-pro-sidebar": "^1.0.0",
     "reading-time": "^1.5.0",
     "remark": "^14.0.2",
     "remark-directive": "^2.0.1",

--- a/packages/site-components/package.json
+++ b/packages/site-components/package.json
@@ -68,7 +68,6 @@
     "next-mdx-remote": "^4.2.1",
     "node-cookie": "^2.1.2",
     "react-error-boundary": "^4.0.11",
-    "react-pro-sidebar": "^1.0.0",
     "rehype-slug": "^5.0.1",
     "swr": "^2.1.2",
     "unified": "^10.0.0",

--- a/packages/site-components/src/Breadcrumbs/Breadcrumb.tsx
+++ b/packages/site-components/src/Breadcrumbs/Breadcrumb.tsx
@@ -11,7 +11,7 @@ export interface BreadcrumbProps {
 }
 
 // TODO replace with Salt Breadcrumb when it supports an API that can customize Links
-export const Breadcrumb = forwardRef<HTMLLinkElement, BreadcrumbProps>(function Breadcrumb(
+export const Breadcrumb = forwardRef<HTMLAnchorElement, BreadcrumbProps>(function Breadcrumb(
   { children, isCurrentLevel, ...props },
   ref
 ) {

--- a/packages/site-components/src/NavigationItem/ExpansionIcon.tsx
+++ b/packages/site-components/src/NavigationItem/ExpansionIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ChevronDownIcon, ChevronRightIcon } from '@salt-ds/icons';
+import { NavigationItemProps } from './NavigationItem';
+
+const iconExpansionMap = {
+  vertical: {
+    expanded: ChevronDownIcon,
+    collapsed: ChevronRightIcon
+  },
+  horizontal: {
+    expanded: ChevronDownIcon,
+    collapsed: ChevronDownIcon
+  }
+};
+
+export function ExpansionIcon({
+  expanded = false,
+  orientation = 'horizontal'
+}: Pick<NavigationItemProps, 'expanded' | 'orientation' | 'className'>) {
+  const Icon = iconExpansionMap[orientation][expanded ? 'expanded' : 'collapsed'];
+  return <Icon aria-hidden="true" />;
+}

--- a/packages/site-components/src/NavigationItem/NavigationItem.tsx
+++ b/packages/site-components/src/NavigationItem/NavigationItem.tsx
@@ -1,0 +1,183 @@
+import React, { AriaAttributes, ForwardedRef, MouseEvent, ReactElement } from 'react';
+import { ComponentPropsWithoutRef, forwardRef, MouseEventHandler } from 'react';
+import { makePrefixer } from '@salt-ds/core';
+import { clsx } from 'clsx';
+import { ExpansionIcon } from './ExpansionIcon';
+
+import { useWindow } from '@salt-ds/window';
+import { useComponentCssInjection } from '@salt-ds/styles';
+
+import navigationItemCss from '@salt-ds/core/dist-es/navigation-item/NavigationItem.css.js';
+
+type OptionalPartial<T, K extends keyof T> = Partial<Pick<T, K>>;
+
+export interface NavigationItemElementProps<T extends HTMLAnchorElement | HTMLButtonElement>
+  extends Pick<AriaAttributes, 'aria-label' | 'aria-expanded' | 'aria-current'> {
+  /**
+   * Item's children.
+   */
+  children: ReactElement;
+  /**
+   * Item's className.
+   */
+  className: string;
+  /**
+   * Handler to expand groups.
+   */
+  onClick?: MouseEventHandler<T>;
+}
+
+export interface NavigationItemRenderProps<T extends HTMLAnchorElement | HTMLButtonElement>
+  extends OptionalPartial<NavigationItemProps, 'active' | 'expanded' | 'level' | 'orientation'> {
+  /**
+   * If the item to render is expandable when clicked.
+   */
+  isParent: boolean;
+  /**
+   * Props to apply to the row's element.
+   */
+  elementProps: NavigationItemElementProps<T>;
+  /**
+   * If row should load page when clicked, the corresponding href.
+   */
+  href?: string;
+}
+export interface NavigationItemProps extends ComponentPropsWithoutRef<'div'> {
+  /**
+   * Whether the navigation item is active.
+   */
+  active?: boolean;
+  /**
+   * Whether the nested group is collapsed and there is an active nested item within it.
+   */
+  blurActive?: boolean;
+  /**
+   * Whether the navigation item is expanded.
+   */
+  expanded?: boolean;
+  /**
+   * Level of nesting.
+   */
+  level?: number;
+  /**
+   * The orientation of the navigation item.
+   */
+  orientation?: 'horizontal' | 'vertical';
+  /**
+   * Whether the navigation item is a parent with nested items.
+   */
+  parent?: boolean;
+  /**
+   * Render prop to enable customisation of navigation item element.
+   */
+  render?: React.FC<NavigationItemRenderProps<HTMLAnchorElement | HTMLButtonElement>>;
+  /**
+   * Action to be triggered when the navigation item is expanded.
+   */
+  onExpand?: MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;
+  /**
+   * Page to load, when this navigation item is selected.
+   */
+  href?: string;
+}
+
+const withBaseName = makePrefixer('saltNavigationItem');
+
+// TODO Replace with latest Salt version once Salt issue closed (currently in PR)
+// https://github.com/jpmorganchase/salt-ds/issues/3279
+export const NavigationItem = forwardRef(function NavigationItem(
+  props: NavigationItemProps,
+  ref: ForwardedRef<HTMLDivElement>
+) {
+  const defaultRender: React.FC<
+    NavigationItemRenderProps<HTMLAnchorElement | HTMLButtonElement>
+  > = props => {
+    const { isParent, elementProps, href } = props;
+    /** Parent rows just expand and collapse and are not links */
+    if (isParent || !href) {
+      return <button {...elementProps} />;
+    }
+    return <a {...elementProps} href={href} />;
+  };
+
+  const {
+    active,
+    blurActive,
+    render = defaultRender,
+    children,
+    className,
+    expanded = false,
+    orientation = 'horizontal',
+    parent,
+    level = 0,
+    onExpand,
+    href,
+    style: styleProp,
+    ...rest
+  } = props;
+
+  const targetWindow = useWindow();
+  useComponentCssInjection({
+    testId: 'salt-navigation-item',
+    css: navigationItemCss,
+    window: targetWindow
+  });
+
+  const style = {
+    ...styleProp,
+    '--saltNavigationItem-level': `${level}`
+  };
+
+  const isParent = !!parent;
+  let elementProps: NavigationItemElementProps<HTMLAnchorElement | HTMLButtonElement> = {
+    className: clsx(
+      withBaseName('wrapper'),
+      {
+        [withBaseName('active')]: active || blurActive,
+        [withBaseName('blurActive')]: blurActive,
+        [withBaseName('rootItem')]: level === 0
+      },
+      withBaseName(orientation)
+    ),
+    children: (
+      <>
+        <span className={withBaseName('label')}>{children}</span>
+        {isParent ? <ExpansionIcon expanded={expanded} orientation={orientation} /> : null}
+      </>
+    )
+  };
+  if (isParent) {
+    const handleExpand = onExpand
+      ? (event: MouseEvent<HTMLButtonElement>) => {
+          event.stopPropagation();
+          onExpand?.(event);
+        }
+      : undefined;
+    elementProps = {
+      ...elementProps,
+      'aria-label': 'expand',
+      'aria-expanded': expanded,
+      onClick: handleExpand
+    } as NavigationItemElementProps<HTMLButtonElement>;
+  } else {
+    elementProps = {
+      ...elementProps,
+      'aria-label': 'change page',
+      'aria-current': active ? 'page' : undefined
+    } as NavigationItemElementProps<HTMLAnchorElement>;
+  }
+
+  return (
+    <div ref={ref} className={clsx(withBaseName(), className)} style={style} {...rest}>
+      {render({
+        active,
+        isParent,
+        href,
+        expanded,
+        level,
+        orientation,
+        elementProps
+      })}
+    </div>
+  );
+});

--- a/packages/site-components/src/NavigationItem/index.ts
+++ b/packages/site-components/src/NavigationItem/index.ts
@@ -1,0 +1,1 @@
+export * from './NavigationItem';

--- a/packages/site-middleware/package.json
+++ b/packages/site-middleware/package.json
@@ -49,7 +49,6 @@
     "next-mdx-remote": "^4.2.1",
     "node-cookie": "^2.1.2",
     "react-error-boundary": "^3.1.4",
-    "react-pro-sidebar": "1.0.0-alpha.7",
     "remark-gfm": "3.0.1",
     "rehype-slug": "^5.0.1",
     "unified": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,13 +1116,6 @@
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
-"@babel/helper-annotate-as-pure@^7.16.0":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
-  integrity sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==
-  dependencies:
-    "@babel/types" "^7.18.6"
-
 "@babel/helper-compilation-targets@^7.18.2":
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz#67a85a10cbd5fc7f1457fec2e7f45441dc6c754b"
@@ -1183,19 +1176,19 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.16.0", "@babel/helper-module-imports@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
-  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
-  dependencies:
-    "@babel/types" "^7.18.6"
-
 "@babel/helper-module-imports@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
   integrity sha1-JWEqgJGpmXBEYciiItDv7F0JFDc=
   dependencies:
     "@babel/types" "^7.16.7"
+
+"@babel/helper-module-imports@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
+  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
+  dependencies:
+    "@babel/types" "^7.18.6"
 
 "@babel/helper-module-transforms@^7.18.0":
   version "7.18.0"
@@ -1440,7 +1433,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.17.12", "@babel/plugin-syntax-jsx@^7.7.2":
+"@babel/plugin-syntax-jsx@^7.7.2":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
   integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
@@ -1526,7 +1519,7 @@
     core-js-pure "^3.30.2"
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.20.13", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.9", "@babel/runtime@^7.20.13", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.22.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
   integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
@@ -1560,7 +1553,7 @@
     "@babel/parser" "^7.22.15"
     "@babel/types" "^7.22.15"
 
-"@babel/traverse@^7.18.0", "@babel/traverse@^7.18.2", "@babel/traverse@^7.19.0", "@babel/traverse@^7.19.3", "@babel/traverse@^7.19.4", "@babel/traverse@^7.20.1", "@babel/traverse@^7.20.5", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.2":
+"@babel/traverse@^7.18.0", "@babel/traverse@^7.18.2", "@babel/traverse@^7.19.0", "@babel/traverse@^7.19.3", "@babel/traverse@^7.19.4", "@babel/traverse@^7.20.1", "@babel/traverse@^7.20.5", "@babel/traverse@^7.7.2":
   version "7.23.2"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.2.tgz#329c7a06735e144a506bdb2cad0268b7f46f4ad8"
   integrity sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==
@@ -1820,123 +1813,10 @@
     human-id "^1.0.2"
     prettier "^2.7.1"
 
-"@emotion/babel-plugin@^11.10.5":
-  version "11.10.5"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz#65fa6e1790ddc9e23cc22658a4c5dea423c55c3c"
-  integrity sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==
-  dependencies:
-    "@babel/helper-module-imports" "^7.16.7"
-    "@babel/plugin-syntax-jsx" "^7.17.12"
-    "@babel/runtime" "^7.18.3"
-    "@emotion/hash" "^0.9.0"
-    "@emotion/memoize" "^0.8.0"
-    "@emotion/serialize" "^1.1.1"
-    babel-plugin-macros "^3.1.0"
-    convert-source-map "^1.5.0"
-    escape-string-regexp "^4.0.0"
-    find-root "^1.1.0"
-    source-map "^0.5.7"
-    stylis "4.1.3"
-
-"@emotion/cache@^11.10.5":
-  version "11.10.5"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
-  integrity sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==
-  dependencies:
-    "@emotion/memoize" "^0.8.0"
-    "@emotion/sheet" "^1.2.1"
-    "@emotion/utils" "^1.2.0"
-    "@emotion/weak-memoize" "^0.3.0"
-    stylis "4.1.3"
-
 "@emotion/hash@^0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
   integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
-
-"@emotion/is-prop-valid@^1.1.0", "@emotion/is-prop-valid@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
-  integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
-  dependencies:
-    "@emotion/memoize" "^0.8.0"
-
-"@emotion/memoize@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
-  integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
-
-"@emotion/react@^11.10.5":
-  version "11.10.5"
-  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
-  integrity sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==
-  dependencies:
-    "@babel/runtime" "^7.18.3"
-    "@emotion/babel-plugin" "^11.10.5"
-    "@emotion/cache" "^11.10.5"
-    "@emotion/serialize" "^1.1.1"
-    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
-    "@emotion/utils" "^1.2.0"
-    "@emotion/weak-memoize" "^0.3.0"
-    hoist-non-react-statics "^3.3.1"
-
-"@emotion/serialize@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
-  integrity sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==
-  dependencies:
-    "@emotion/hash" "^0.9.0"
-    "@emotion/memoize" "^0.8.0"
-    "@emotion/unitless" "^0.8.0"
-    "@emotion/utils" "^1.2.0"
-    csstype "^3.0.2"
-
-"@emotion/sheet@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
-  integrity sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==
-
-"@emotion/styled@^11.10.5":
-  version "11.10.5"
-  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.10.5.tgz#1fe7bf941b0909802cb826457e362444e7e96a79"
-  integrity sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==
-  dependencies:
-    "@babel/runtime" "^7.18.3"
-    "@emotion/babel-plugin" "^11.10.5"
-    "@emotion/is-prop-valid" "^1.2.0"
-    "@emotion/serialize" "^1.1.1"
-    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
-    "@emotion/utils" "^1.2.0"
-
-"@emotion/stylis@^0.8.4":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
-  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
-
-"@emotion/unitless@^0.7.4":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
-  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
-
-"@emotion/unitless@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
-  integrity sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==
-
-"@emotion/use-insertion-effect-with-fallbacks@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
-  integrity sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==
-
-"@emotion/utils@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
-  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
-
-"@emotion/weak-memoize@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
-  integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -2832,11 +2712,6 @@
   optionalDependencies:
     fsevents "2.3.2"
 
-"@popperjs/core@^2.11.6":
-  version "2.11.6"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
-  integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
-
 "@rushstack/eslint-patch@^1.1.3":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
@@ -3696,11 +3571,6 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha1-0zV0eaD9/dWQf+Z+F+CoXJBuEwE=
 
-"@types/parse-json@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
-  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
-
 "@types/prettier@^2.1.5":
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.1.tgz#dfd20e2dc35f027cdd6c1908e80a5ddc7499670e"
@@ -4494,31 +4364,6 @@ babel-plugin-jest-hoist@^29.2.0:
     "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
-  integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    cosmiconfig "^7.0.0"
-    resolve "^1.19.0"
-
-"babel-plugin-styled-components@>= 1.12.0":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz#c81ef34b713f9da2b7d3f5550df0d1e19e798086"
-  integrity sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.0"
-    "@babel/helper-module-imports" "^7.16.0"
-    babel-plugin-syntax-jsx "^6.18.0"
-    lodash "^4.17.11"
-    picomatch "^2.3.0"
-
-babel-plugin-syntax-jsx@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
-  integrity sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==
-
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
@@ -4756,11 +4601,6 @@ camelcase@^6.2.0, camelcase@^6.3.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-camelize@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
-  integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
-
 caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001400:
   version "1.0.30001436"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz"
@@ -4932,7 +4772,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-classnames@^2.2.5, classnames@^2.3.1, classnames@^2.3.2:
+classnames@^2.2.5, classnames@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
@@ -5138,11 +4978,6 @@ constant-case@^3.0.4:
     tslib "^2.0.3"
     upper-case "^2.0.2"
 
-convert-source-map@^1.5.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
-  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
-
 convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
@@ -5200,17 +5035,6 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
-  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
-  dependencies:
-    "@types/parse-json" "^4.0.0"
-    import-fresh "^3.2.1"
-    parse-json "^5.0.0"
-    path-type "^4.0.0"
-    yaml "^1.10.0"
-
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -5263,20 +5087,6 @@ crypt@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
-
-css-color-keywords@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
-  integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
-
-css-to-react-native@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
-  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
-  dependencies:
-    camelize "^1.0.0"
-    css-color-keywords "^1.0.0"
-    postcss-value-parser "^4.0.2"
 
 css-what@^5.0.1:
   version "5.1.0"
@@ -6872,11 +6682,6 @@ find-my-way@^7.6.0:
     fast-querystring "^1.0.0"
     safe-regex2 "^2.0.0"
 
-find-root@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
-  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
-
 find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
@@ -7402,7 +7207,7 @@ highlight.js@^10.4.1, highlight.js@~10.7.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -8854,7 +8659,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=
@@ -10899,7 +10704,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw=
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.0, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=
@@ -10970,11 +10775,6 @@ playwright-core@1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.33.0.tgz#269efe29a927cd6d144d05f3c2d2f72bd72447a1"
   integrity sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==
-
-postcss-value-parser@^4.0.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
-  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@8.4.14:
   version "8.4.14"
@@ -11388,25 +11188,6 @@ react-markdown@^6.0.2:
     unified "^9.0.0"
     unist-util-visit "^2.0.0"
     vfile "^4.0.0"
-
-react-pro-sidebar@1.0.0-alpha.7:
-  version "1.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/react-pro-sidebar/-/react-pro-sidebar-1.0.0-alpha.7.tgz#4b6558b58c5db568a938c1d58a263eafd270c11b"
-  integrity sha512-6djCGLrLAHRQkdIWH7Vk1jdgYIQi2cxvEXD5tKToxwSbHaWvhe9l6pAxk9cmn9Xh1rYDxa5YEtfXLqAug5KGRg==
-  dependencies:
-    "@popperjs/core" "^2.11.6"
-    classnames "^2.3.2"
-    styled-components "^5.3.6"
-
-react-pro-sidebar@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-pro-sidebar/-/react-pro-sidebar-1.0.0.tgz#c1836b06da2e4d9614c227e9276c149317f36494"
-  integrity sha512-TAU3vHj0rYHSLWdZksiWte59dwh3rweaFY+dXri+y8mtlbQalxnNTG11k9wRCiaMa0IGPmIIbdY1E1yoHBUd/A==
-  dependencies:
-    "@emotion/react" "^11.10.5"
-    "@emotion/styled" "^11.10.5"
-    "@popperjs/core" "^2.11.6"
-    classnames "^2.3.2"
 
 react-redux@^8.0.5:
   version "8.1.1"
@@ -11895,7 +11676,7 @@ resolve@^1.10.0, resolve@^1.20.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^1.19.0, resolve@^1.22.0, resolve@^1.22.1:
+resolve@^1.22.0, resolve@^1.22.1:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -12136,11 +11917,6 @@ sha.js@^2.4.11:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
-
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -12324,11 +12100,6 @@ source-map-support@^0.5.17:
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
-
-source-map@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
 
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
@@ -12621,22 +12392,6 @@ style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-styled-components@^5.3.6:
-  version "5.3.6"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.6.tgz#27753c8c27c650bee9358e343fc927966bfd00d1"
-  integrity sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^1.1.0"
-    "@emotion/stylis" "^0.8.4"
-    "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1.12.0"
-    css-to-react-native "^3.0.0"
-    hoist-non-react-statics "^3.0.0"
-    shallowequal "^1.1.0"
-    supports-color "^5.5.0"
-
 styled-jsx@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.1.1.tgz#839a1c3aaacc4e735fed0781b8619ea5d0009d1f"
@@ -12644,7 +12399,7 @@ styled-jsx@5.1.1:
   dependencies:
     client-only "0.0.1"
 
-stylis@4.1.3, stylis@^4.1.2:
+stylis@^4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
   integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
@@ -12654,7 +12409,7 @@ stylis@^4.2.0:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.0.tgz#abe305a669fc3d8777e10eefcfc73ad861c5588c"
   integrity sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==
 
-supports-color@^5.3.0, supports-color@^5.5.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=
@@ -13904,11 +13659,6 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=
-
-yaml@^1.10.0:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^2.1.1:
   version "2.1.3"


### PR DESCRIPTION
… Salt's `NavigationItem`

We will remove this local `NavigationItem` once Salt merges it's own PR.