### PR TITLE
Baseline css size

### DIFF
--- a/.changeset/grumpy-turkeys-crash.md
+++ b/.changeset/grumpy-turkeys-crash.md
@@ -1,0 +1,5 @@
+---
+'@jpmorganchase/mosaic-theme': patch
+---
+
+Reduce the size of the baseline CSS file

--- a/packages/theme/src/baseline/baseline.css.ts
+++ b/packages/theme/src/baseline/baseline.css.ts
@@ -1,5 +1,5 @@
 import { globalStyle } from '@vanilla-extract/css';
-import { ssrClassName } from '../index';
+import { ssrClassName } from '../ssrClassName';
 
 globalStyle('html, body', {
   fontFamily: 'var(--salt-text-fontFamily, "Open Sans")',

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { shadow } from './shadow';
 import { vars } from './vars.css';
 
-export const ssrClassName = 'mosaic-ssr';
+export * from './ssrClassName';
 export { themeClassName, vars } from './vars.css';
 export * from './animation';
 export * from './blockquote';

--- a/packages/theme/src/ssrClassName.ts
+++ b/packages/theme/src/ssrClassName.ts
@@ -1,0 +1,1 @@
+export const ssrClassName = 'mosaic-ssr';


### PR DESCRIPTION
Reduces the size of the baseline CSS considerably

Before: 552KB
After: 371 B (not KB)