### PR TITLE
Relax navigation width condition

### DIFF
--- a/.changeset/mighty-monkeys-switch.md
+++ b/.changeset/mighty-monkeys-switch.md
@@ -1,0 +1,5 @@
+---
+'@jpmorganchase/mosaic-site-components': patch
+---
+
+Relax navigation width condition for different responsive usage

--- a/.changeset/perfect-cougars-grab.md
+++ b/.changeset/perfect-cougars-grab.md
@@ -1,0 +1,5 @@
+---
+'@jpmorganchase/mosaic-store': patch
+---
+
+Add displayName for `StoreContext`

--- a/packages/site-components/src/Sidebar/styles.css.ts
+++ b/packages/site-components/src/Sidebar/styles.css.ts
@@ -6,7 +6,7 @@ export default {
     {
       zIndex: 3,
       flexGrow: 0,
-      width: '300px'
+      minWidth: '300px'
     },
     sidebar.container
   ]),

--- a/packages/site-components/src/VerticalNavigation.tsx
+++ b/packages/site-components/src/VerticalNavigation.tsx
@@ -117,7 +117,7 @@ export const VerticalNavigation: React.FC<VerticalNavigationProps> = ({
         data-testid="vertical-navigation"
         as="ul"
         gap="var(--salt-size-border)"
-        style={{ width: 250, listStyle: 'none', paddingLeft: 0 }}
+        style={{ minWidth: 250, listStyle: 'none', paddingLeft: 0 }}
       >
         {menu.map(item =>
           renderNavigationItem(

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -53,6 +53,7 @@ function getDefaultInitialState(): DefaultSiteState {
 }
 
 const StoreContext = createContext<typeof store | undefined>(undefined);
+StoreContext.displayName = 'StoreContext';
 const StoreProvider = StoreContext.Provider;
 
 const storeMiddlewares = stateCreatorFn =>


### PR DESCRIPTION
To help Salt site, navigation component will be rendered in different density. Preview [salt-ds#4135](https://github.com/jpmorganchase/salt-ds/pull/4135)

I couldn't find any breakage on Mosaic site preview